### PR TITLE
Docstrings, documentation, unit tests, bug fixes, and refactors

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,8 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install flake8 pytest
         pip install -r requirements.txt
+        # install scintools itself so `import scintools` works under pytest
+        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -37,4 +39,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistic
     - name: Test with pytest
       run: |
-        pytest tests/
+        python -m pytest tests/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,3 +35,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistic
+    - name: Test with pytest
+      run: |
+        pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 scintools/.DS_Store
+__pycache__/
+*.pyc
+.pytest_cache/
 scintools/*.pyc
 scintools/__pycache__/*
 scintools/__pycache__

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -23,6 +23,28 @@ breakages**, most of them triggered by ordinary default usage or by the move to 
 
 Counts: **10 confirmed bugs**, **5 plausible/suspected issues**.
 
+## Resolution status
+
+All 10 confirmed bugs have been fixed, plus 4 of the 5 plausible issues and the
+`plt.colorbar` no-op:
+
+- **Fixed** — Bugs 1-10 (see each entry below), plus the plausible issues
+  `effective_velocity_annual` INC-before-assignment (now raises `KeyError`),
+  `norm_sspec` logsteps mask (`mask` -> `masklin`), in-place mutation of caller
+  weights in `tau_acf_model`/`dnu_acf_model` (now copied), `np.float128` ->
+  `np.longdouble` portability, and the `plt.colorbar` missing-parentheses no-op.
+  A latent follow-on bug exposed by the `BasicDyn` fix (`self.tobs` used the
+  raw `dt` arg instead of `self.dt`) was also fixed.
+- **Deliberately NOT changed** — the `scint_velocity` error-propagation term
+  (`scint_utils.py`). This is a scientific formula whose dimensional intent
+  (`coeff_err` as variance vs. standard error) needs domain confirmation;
+  changing it blindly could silently corrupt published results. Flagged for the
+  maintainer's review.
+- Refactoring opportunities below were **not** applied (out of scope for a
+  bug-fix pass).
+
+Regression tests covering the fixes were added under `tests/`.
+
 ## Bugs (most severe first)
 
 ### 1. `np.complex_` removed in NumPy 2.0 — `ACF` class unusable

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,186 @@
+# Scintools Code Review
+
+Scope: `scintools/dynspec.py`, `scintools/scint_models.py`, `scintools/scint_sim.py`,
+`scintools/scint_utils.py`, `scintools/ththmod.py`. Review performed read-only against
+the installed environment (numpy 2.4.6, scipy 1.17.1, matplotlib 3.11.0; skimage/emcee/bilby absent).
+
+## Summary
+
+Overall the scientific core is reasonable, but there are several **confirmed, high-impact
+breakages**, most of them triggered by ordinary default usage or by the move to modern NumPy:
+
+1. **`ACF()` is completely broken on NumPy >= 2.0** because it uses the removed alias
+   `np.complex_` (`scint_sim.py`). This also takes down the analytic 2D ACF model in
+   `scint_models.scint_acf_model_2d` and the `method='acf2d'` fit path in `dynspec.py`.
+2. **`Dynspec.fit_arc()` raises `TypeError` in its default (non-lamsteps) mode** because the
+   default `constraint=[0, np.inf]` is a Python list that is divided by a float.
+3. **`SimDyn.__init__` raises `AttributeError` immediately** (`self.header = self.header`),
+   so importing a `Simulation` into the Dynspec framework via `SimDyn` never works.
+4. A copy/paste slip in `get_scint_params` (`acf2d` cropping) corrupts the time-axis crop when
+   `nscale` exceeds the frequency range.
+5. Broad code duplication (SVD models, the chunk-mask block repeated ~6× in `ththmod.py`, window
+   construction, NaN interpolation) and several 300–500 line functions make maintenance risky.
+
+Counts: **10 confirmed bugs**, **5 plausible/suspected issues**.
+
+## Bugs (most severe first)
+
+### 1. `np.complex_` removed in NumPy 2.0 — `ACF` class unusable
+- **File**: `scint_sim.py:589` and `scint_sim.py:634` (dtype=`np.complex_`)
+- **Severity**: High · **Confidence**: Confirmed
+- **What's wrong**: `np.complex_` was removed in NumPy 2.0.
+- **Why it fails**: Verified — `ACF(nf=11, nt=11)` raises
+  `AttributeError: 'np.complex_' was removed in the NumPy 2.0 release. Use 'np.complex128' instead.`
+  Because `ACF` is imported and used by `scint_models.scint_acf_model_2d` (line 190) and by the
+  `method='acf2d'` branch of `Dynspec.get_scint_params`, the analytic 2D ACF fit is dead on modern NumPy.
+- **Fix**: Replace `np.complex_` with `np.complex128`. (Also `np.complex_` in `scint_sim.py` are the
+  only two occurrences.)
+
+### 2. `fit_arc` divides a list by a float in the default path
+- **File**: `dynspec.py:1147-1148` (`constraint = constraint/(self.freq/ref_freq)**2`)
+- **Severity**: High · **Confidence**: Confirmed
+- **What's wrong**: The public default is `constraint=[0, np.inf]` (line 973), a Python list.
+  When `lamsteps=False` (the default) the `if not lamsteps:` block divides `constraint` by a scalar.
+- **Why it fails**: Verified — `[0, np.inf] / 1.0` raises
+  `TypeError: unsupported operand type(s) for /: 'list' and 'float'`. So `dyn.fit_arc()` with defaults
+  crashes; it only works if the caller passes `constraint` as an ndarray or uses `lamsteps=True`.
+- **Fix**: Coerce once at the top, e.g. `constraint = np.array(constraint, dtype=float)`.
+
+### 3. `SimDyn.__init__` reads `self.header` before it is set
+- **File**: `dynspec.py:4283` (`self.header = self.header`)
+- **Severity**: High · **Confidence**: Confirmed
+- **What's wrong**: `self.header` is assigned from itself before ever being defined.
+- **Why it fails**: A fresh `SimDyn` instance has no `header` attribute, so the RHS raises
+  `AttributeError`. `SimDyn(sim)` therefore always fails.
+- **Fix**: Set it from the simulation, e.g. `self.header = [self.name]` (mirroring `Simulation.header`).
+
+### 4. Copy/paste error in `get_scint_params` acf2d cropping
+- **File**: `dynspec.py:2766-2767` (inside `if ndnu > (self.bw / dnu):`)
+- **Severity**: Medium · **Confidence**: Confirmed (by inspection)
+- **What's wrong**: The frequency-overflow branch sets `tmin = 0; tmax = nf`, but it should set the
+  **frequency** indices (`fmin = 0; fmax = nf`). The analogous time branch (lines 2754-2755) correctly
+  sets `tmin/tmax`. The subsequent crop is `ydata_2d = ydata_centered[fmin:fmax, tmin:tmax]` (line 2775).
+- **Why it fails**: When `nscale` exceeds the available frequency range, the time indices are clobbered
+  (and with `nf`, a frequency count, on a time axis), while `fmin/fmax` keep their earlier centred values.
+  The 2D fit is then cropped over the wrong region.
+- **Fix**: Change to `fmin = 0; fmax = nf`.
+
+### 5. `BasicDyn` mutable default args + `.size` on a list default
+- **File**: `dynspec.py:4148` (`header=["BasicDyn"], times=[], freqs=[]`) and `dynspec.py:4195`
+  (`if times.size == 0 or freqs.size == 0:`)
+- **Severity**: Medium · **Confidence**: Confirmed
+- **What's wrong**: (a) Mutable default arguments (`["BasicDyn"]`, `[]`, `[]`). (b) The guard calls
+  `.size` on `times`/`freqs`, but the defaults are lists, which have no `.size`.
+- **Why it fails**: Verified — `[].size` raises `AttributeError`. So `BasicDyn(dyn)` with default
+  time/freq axes raises `AttributeError` instead of the intended `ValueError`. (Callers such as
+  `Dynspec.__add__` pass ndarrays, so they avoid it, but the documented direct construction breaks.)
+- **Fix**: Use `times=None`/`freqs=None` defaults and check `if times is None or len(times) == 0`.
+
+### 6. `tau_sspec_model` / `dnu_sspec_model` signature mismatch
+- **File**: `scint_models.py:218` and `:248` (defined with 3 params) vs `scint_models.py:281-282`
+  (called with 4 args, passing `weights[0]`/`weights[1]`)
+- **Severity**: Medium · **Confidence**: Confirmed (by inspection); currently latent
+- **What's wrong**: `scint_sspec_model` calls `tau_sspec_model(params, xdata[0], ydata[0], weights[0])`
+  but the callees accept only `(params, xdata, ydata)`. Calling `scint_sspec_model` would raise
+  `TypeError: too many positional arguments`.
+- **Why it doesn't currently bite**: The only caller (`dynspec.py:2937`) is commented out and the
+  `sspec` method prints "This method doesn't work yet". Still a real defect if the path is revived.
+- **Fix**: Give the `_sspec_model` functions a `weights` parameter (matching the acf models) and use it.
+
+### 7. `except NameError` cannot catch a missing dict key
+- **File**: `dynspec.py:4233-4241` (`MatlabDyn`), also relevant to `SimDyn`
+- **Severity**: Low · **Confidence**: Confirmed
+- **What's wrong**: `self.matfile['spi']` / `self.matfile['dlam']` raise `KeyError` when absent, but the
+  handlers catch `NameError`.
+- **Why it fails**: Verified — a missing dict key raises `KeyError`, which the `except NameError` clause
+  does not catch, so the intended friendly `NameError('No variable named ...')` is never raised; the raw
+  `KeyError` propagates instead.
+- **Fix**: `except KeyError:`.
+
+### 8. `calc_sspec` trapezoid branch checks the wrong attribute
+- **File**: `dynspec.py:3657` (`if not hasattr(self, 'trap'):`)
+- **Severity**: Low · **Confidence**: Confirmed
+- **What's wrong**: The cached array is `self.trapdyn`, but the guard tests `self.trap`. Since `self.trap`
+  is never set, the branch always recomputes `scale_dyn(scale='trapezoid')`. Functionally correct output
+  but redundant work / dead cache.
+- **Fix**: `if not hasattr(self, 'trapdyn'):`.
+
+### 9. `plot_dyn` intensity-scaling mask loses the nonzero filter
+- **File**: `dynspec.py:500-506`
+- **Severity**: Low · **Confidence**: Confirmed
+- **What's wrong**: The mask is written `dyn[is_valid(dyn)*np.array(np.abs(is_valid(dyn)) > 0)]`.
+  `np.abs(is_valid(dyn)) > 0` is just `is_valid(dyn)` again, so the expression reduces to
+  `is_valid(dyn)` and the "nonzero pixel" filter is silently dropped. Compare `plot_sspec` (line 787),
+  which correctly uses `np.abs(sspec) > 0`.
+- **Why it matters**: `vmin/vmax` for the dynamic-spectrum plot are computed over zero-filled pixels too,
+  skewing the colour scale. Cosmetic only.
+- **Fix**: Use `is_valid(dyn) * (np.abs(dyn) > 0)`.
+
+### 10. `arc_power_curve` returns a broken/empty model
+- **File**: `scint_models.py:287-297`
+- **Severity**: Low · **Confidence**: Confirmed (dead/placeholder)
+- **What's wrong**: `model = []` then `return (ydata - model) * weights`. `ydata - []` broadcasts to an
+  empty array (or errors depending on shapes); the function cannot produce meaningful residuals.
+- **Fix**: Either implement the template or remove the stub.
+
+## Plausible / suspected issues
+
+- **`effective_velocity_annual` may use `INC` before assignment** — `scint_models.py:532-555`.
+  If none of `KIN`/`COSI`/`SINI` is in `params`, the code only prints a warning and never sets `INC`,
+  then references `np.sin(INC)` at line 555 → `NameError`. Confidence: high that it errors, but only on
+  a malformed parameter set.
+- **`norm_sspec` logsteps path applies the wrong mask** — `dynspec.py:2116-2117`. `masklin` is computed
+  but the masked array is built with `mask=mask` (the non-log mask). Looks like a copy/paste slip;
+  `normSspeclin` should probably use `masklin`. Only affects `logsteps=True`.
+- **`scint_velocity` error propagation** — `scint_utils.py:760-763`. `viss_err` adds `coeff_err`
+  (a variance-like term) directly inside `np.sqrt(coeff**2*(...) + coeff_err)`; dimensionally this looks
+  like it should be `coeff_err**2` (or `coeff_err` should already be a variance). Worth a domain check.
+- **In-place mutation of caller weights** — `scint_models.py:81,105` (`weights[0] = 0`). `tau_acf_model`
+  / `dnu_acf_model` zero the first weight of the array passed in by the caller. It is idempotent here so
+  harmless in practice, but it mutates `get_scint_params`' `weights_t`/`weights_f` arrays as a side effect.
+- **`np.float128` is not portable** — `scint_utils.py:543`, `dynspec.py:3982-3983`. It exists on this
+  Linux host but is absent on Windows and Apple-silicon macOS, where these lines will raise
+  `AttributeError`. Consider `np.longdouble`.
+
+## Refactoring opportunities
+
+1. **Duplicated `svd_model`** — `scint_utils.py:705` and `ththmod.py:18`. Same SVD core, but the utils
+   version returns `(arr/|model|, model)` while the ththmod version returns only `model`. `dynspec.py`
+   imports the utils one; ththmod uses its own. Consolidate into one function with a documented return
+   contract to avoid drift.
+2. **The chunk/mask block is copy-pasted ~6 times in `ththmod.py`** — `mosaic` (1515-1553), `rotMos`
+   (1734-1769), `rotInit` (1815-1856), `rotDer` (1878-1919), `fullMos` (1948-1987), `fullMosGrad`
+   (2044-2101), `fullMosHess` (2132-2239). The `mask_func` weighting logic is identical each time.
+   Extract a helper `chunk_mask(cf, ct, ncf, nct, cwf, cwt)`.
+3. **Window construction is duplicated** — `scint_utils.get_window` (810) vs the inline hanning/hamming/
+   blackman/bartlett block in `dynspec.scale_dyn` (4086-4105). Call `get_window` in `scale_dyn`.
+4. **NaN interpolation duplicated** — `scint_utils.interp_nan_2d` (769) vs the inline griddata "clean"
+   block in `dynspec.calc_scattered_image` (3527-3548). Reuse the utility.
+5. **Overly long functions** — `Dynspec.get_scint_params` (~2470-3156, ~500 lines), `Dynspec.fit_arc`
+   (~970-1347), `Dynspec.norm_sspec` (~1920-2281), `ACF.calc_acf` in scint_sim. These would benefit from
+   decomposition (e.g. separate 1D-init, approx-2D, analytic-2D, and plotting stages in
+   `get_scint_params`).
+6. **Dead / commented-out code** — the `sspec` method body in `get_scint_params` (2911-2944) is entirely
+   commented and prints "doesn't work yet"; `scint_models.arc_power_curve` is a stub;
+   `scint_utils.make_dynspec` (894) is an empty placeholder; various commented arrays in `scint_sim`.
+7. **Unused / misleading parameters** — `Dynspec.trim_edges(..., remove_short_sub=True)` (259) never uses
+   `remove_short_sub`; `auto_processing` forwards it (line 435). Either wire it up or drop it.
+8. **Magic numbers / hardcoded constants** — the speed of light is redefined as a literal `299792458.0`
+   in many places (`dynspec.py:904,1141,2033,3500`, `scint_sim.py:130`) alongside available
+   `scipy.constants`/`astropy.constants`. The LSR solar motion `(11.1, 12.24, 7.25)` in
+   `scint_utils.make_lsr` (343) and galactic radius/velocities in `differential_velocity` are hardcoded.
+9. **`slow_FT` uses a hardcoded reference frequency** at mid-band (`scint_utils.py:682-684`), flagged in
+   its own comment ("should change this").
+
+## Deprecations / compatibility (modern numpy/scipy/matplotlib)
+
+- **`np.complex_`** — removed in NumPy 2.0. Breaks `ACF` (see Bug 1). Use `np.complex128`.
+  (`np.complex_dtype` scan: only `scint_sim.py:589,634`.)
+- **`np.float128`** — not a portable alias (absent on Windows / Apple silicon). `scint_utils.py:543`,
+  `dynspec.py:3982-3983`. Prefer `np.longdouble`.
+- **`plt.colorbar` missing call parentheses** — `scint_sim.py:399` (`plt.colorbar` with no `()`), so no
+  colorbar is ever drawn in `Simulation.plot_pulse`. Not a deprecation but a latent no-op.
+- No usages of the fully-removed `np.int`/`np.float`/`np.bool` aliases were found in these modules
+  (the earlier-numpy breakages are limited to `np.complex_` and the `np.float128` portability caveat).
+- `scipy`/`matplotlib` APIs used (`convolve2d`, `medfilt`, `savgol_filter`, `RectBivariateSpline`,
+  `pcolormesh(..., shading='auto')`, `eigsh`, `curve_fit`) are all current in the installed versions.

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -21,12 +21,13 @@ breakages**, most of them triggered by ordinary default usage or by the move to 
 5. Broad code duplication (SVD models, the chunk-mask block repeated ~6× in `ththmod.py`, window
    construction, NaN interpolation) and several 300–500 line functions make maintenance risky.
 
-Counts: **10 confirmed bugs**, **5 plausible/suspected issues**.
+Counts: **10 confirmed bugs**, **5 plausible/suspected issues**, plus **1
+additional bug found during the fix pass** (`slow_FT`, below).
 
 ## Resolution status
 
-All 10 confirmed bugs have been fixed, plus 4 of the 5 plausible issues and the
-`plt.colorbar` no-op:
+All 10 confirmed bugs have been fixed, plus 4 of the 5 plausible issues, the
+`plt.colorbar` no-op, and every applicable refactoring opportunity:
 
 - **Fixed** — Bugs 1-10 (see each entry below), plus the plausible issues
   `effective_velocity_annual` INC-before-assignment (now raises `KeyError`),
@@ -35,15 +36,35 @@ All 10 confirmed bugs have been fixed, plus 4 of the 5 plausible issues and the
   `np.longdouble` portability, and the `plt.colorbar` missing-parentheses no-op.
   A latent follow-on bug exposed by the `BasicDyn` fix (`self.tobs` used the
   raw `dt` arg instead of `self.dt`) was also fixed.
-- **Deliberately NOT changed** — the `scint_velocity` error-propagation term
-  (`scint_utils.py`). This is a scientific formula whose dimensional intent
-  (`coeff_err` as variance vs. standard error) needs domain confirmation;
-  changing it blindly could silently corrupt published results. Flagged for the
-  maintainer's review.
-- Refactoring opportunities below were **not** applied (out of scope for a
-  bug-fix pass).
+- **New bug found & fixed** — `slow_FT` (`scint_utils.py`) called
+  `np.fft.fftshift(SS, axis=0)`; numpy's kwarg is `axes`, so the function
+  raised `TypeError` on every call (it had never worked). Fixed to `axes=0`,
+  and the hard-coded mid-band reference frequency was made an optional `fref`
+  parameter (default preserves the previous mid-band behavior).
+- **Refactors applied** — consolidated the duplicated `svd_model` onto a shared
+  `scint_utils.svd_reconstruct` core; extracted the ~6x-repeated mosaic mask
+  block in `ththmod.py` into a single `chunk_mask` helper (verified bit-for-bit
+  identical output on all 9 affected functions); replaced the inline window
+  construction in `scale_dyn` with `get_window`; centralized the
+  `c = 299792458.0` literal onto `scipy.constants.c`; and removed the large
+  commented-out `sspec`-method implementation block.
+- **Deliberately NOT changed** —
+  - the `scint_velocity` error-propagation term (`scint_utils.py`): a scientific
+    formula whose dimensional intent needs domain confirmation; changing it
+    blindly could silently corrupt published results.
+  - `calc_scattered_image`'s inline griddata fill was **not** merged into
+    `interp_nan_2d`: it masks `array < 1e-22` whereas `interp_nan_2d` masks
+    NaN/inf, so consolidating would change the masking semantics.
+  - the long functions (`get_scint_params`, `fit_arc`, `norm_sspec`,
+    `ACF.calc_acf`) were **not** decomposed: they are the untested scientific
+    core, and splitting them without characterization tests risks silently
+    altering results. Recommended as future work once such tests exist.
+  - `trim_edges`'s unused `remove_short_sub` parameter was documented as
+    reserved/currently-unused rather than dropped, to avoid a public-API break.
+  - `make_dynspec` (documented placeholder) and single-use astronomical
+    constants were left as-is.
 
-Regression tests covering the fixes were added under `tests/`.
+Regression tests covering the fixes and refactors were added under `tests/`.
 
 ## Bugs (most severe first)
 

--- a/docs/source/acf.rst
+++ b/docs/source/acf.rst
@@ -1,28 +1,69 @@
 ACF class
 ================
 
-The scintools ``ACF`` class, found in the ``scint_sim`` module, features tools for simulating and plotting autocorrelation functions. Based on the theoretical treatment found in Appendix A of `Rickett, Coles et al. (2014) <https://iopscience.iop.org/article/10.1088/0004-637X/787/2/161/>`_.
+The scintools ``ACF`` class, found in the ``scint_sim`` module, features tools for simulating and plotting autocorrelation functions. Based on the theoretical treatment found in Appendix A of `Rickett, Coles et al. (2014) <https://iopscience.iop.org/article/10.1088/0004-637X/787/2/161/>`_. The magnitude of the effective velocity is defined to be 1, so time and frequency lags are expressed in units of the (isotropic) scintillation timescale and decorrelation bandwidth respectively.
 
 .. raw:: html
 
-	<em class="property">class </em><code class="descclassname">scintools.</code><code class="descname">ACF</code><span class="sig-paren">(</span><em>s_max=5, dnu_max=5, ns=256, nf=256, ar=1, alpha=5/3, phasegrad_x=0, phasegrad_y=0, V_x=1, V_y=0, psi=0, amp=1</em><span class="sig-paren">)</span>
+	<em class="property">class </em><code class="descclassname">scintools.</code><code class="descname">ACF</code><span class="sig-paren">(</span><em>psi=0, phasegrad=0, theta=0, ar=1, alpha=5/3, taumax=4, dnumax=4, nf=51, nt=51, amp=1, wn=0, spatial_factor=2, resolution_factor=1, core_factor=2, auto_sampling=True, plot=False, display=True</em><span class="sig-paren">)</span>
 
 \
-		Simulation class.
+		ACF class. On construction, computes the ACF from the theoretical function.
 
-		**Parameters:** 
-				*   **s_max** (`float, optional`) - number of coherence spatial scales to calculate over.
-				*   **dnu_max** (`float, optional`) - number of decorrelation bandwidths to calculate over.
-				*   **ns** (`int, optional`) - number of spatial steps
-				*   **nf** (`int, optional`) - number of frequency steps.
-				*   **ar** (`float, optional`) - axial ratio of anisotropy
+		**Parameters:**
+				*   **psi** (`float, optional`) - angle (degrees) of the velocity vector with respect to the major axis of the (brightness) anisotropy.
+				*   **phasegrad** (`float, optional`) - magnitude of the phase gradient (e.g. due to a binary companion).
+				*   **theta** (`float, optional`) - angle (degrees) of the phase gradient with respect to the velocity vector.
+				*   **ar** (`float, optional`) - axial ratio of anisotropy.
 				*   **alpha** (`float, optional`) - structure function exponent. 5/3 is a Kolmogorov profile (default) while 2 is Gaussian.
-				*   **phasegrad_x** (`float, optional`) - phase gradient in x
-				*   **phasegrad_y** (`float, optional`) - phase gradient in y
-				*   **V_x** (`float, optional`) - effective velocity in the x direction
-				*   **V_y** (`float, optional`) - effective velocity in the y direction
-				*   **psi** (`float, optional`) - orientation of anisotropy in degrees
-				*   **amp** (`float, optional`) - amplitude to scale the ACF by. By default ACF is normalized to the range [0, 1].
+				*   **taumax** (`float, optional`) - number of scintillation timescales to compute the ACF out to (equivalently, the ACF in space goes out to ``taumax*V``).
+				*   **dnumax** (`float, optional`) - number of decorrelation bandwidths to compute the ACF out to.
+				*   **nf** (`int, optional`) - number of frequency-lag samples in the ACF. If not odd, it is incremented by one so the ACF has a well-defined centre.
+				*   **nt** (`int, optional`) - number of time-lag samples in the ACF. If not odd, it is incremented by one so the ACF has a well-defined centre.
+				*   **amp** (`float, optional`) - amplitude to scale the ACF by. By default the ACF peaks at 1.
+				*   **wn** (`float, optional`) - size of the white-noise spike at the origin of the ACF.
+				*   **spatial_factor** (`float, optional`) - multiplier for the spatial extent (``taumax``) used when calculating the ACF of the electric field. Only used if ``auto_sampling`` is False.
+				*   **resolution_factor** (`float, optional`) - multiplier applied to the default spatial resolution used when calculating the ACF of the electric field. Only used if ``auto_sampling`` is False.
+				*   **core_factor** (`float, optional`) - additional resolution multiplier applied near the origin (first frequency-lag sample). Only used if ``auto_sampling`` is False.
+				*   **auto_sampling** (`bool, optional`) - if True, automatically set the spatial sampling factors based on ``ar`` and ``taumax`` to avoid sampling artefacts, overriding ``spatial_factor``, ``resolution_factor``, and ``core_factor``. Warning: computation time increases sharply for large ``ar``.
+				*   **plot** (`bool, optional`) - if True, plot the ACF after it is computed.
+				*   **display** (`bool, optional`) - if True and ``plot`` is True, show the plot immediately.
+
+Example
+-------
+
+.. code-block:: python
+
+	from scintools.scint_sim import ACF
+
+	# Quick look with default parameters
+	acf_obj = ACF()
+	acf_obj.plot_acf()          # the ACF
+	acf_obj.plot_acf_efield()   # the ACF of the electric field
+	acf_obj.plot_sspec()        # the secondary spectrum (Hanning window applied by default)
+	acf_obj.calc_sspec(window='blackman', window_frac=1.0)  # change the window and its size
+	acf_obj.plot_sspec()
+
+	# An ACF with anisotropy and a phase gradient (e.g. a binary companion)
+	ar = 2            # axial ratio of anisotropy
+	psi = 30          # angle of velocity relative to major axis (defined as x)
+	phasegrad = 0.2   # magnitude of phase gradient
+	theta = 0         # angle of phase gradient relative to velocity
+	taumax = 4        # number of scintillation timescales to compute to
+	dnumax = 4        # number of decorrelation bandwidths to compute to
+	nt = 51           # number of time samples in the ACF
+	nf = 51           # number of frequency samples in the ACF
+	auto_sampling = True  # dynamically set spatial properties to avoid ACF artefacts
+
+	my_acf = ACF(psi=psi, phasegrad=phasegrad, theta=theta, ar=ar,
+	             taumax=taumax, dnumax=dnumax, nt=nt, nf=nf)
+	my_acf.plot_acf()
+	my_acf.plot_sspec()
+
+	# Raw arrays are available for custom plotting
+	acf = my_acf.acf
+	t = my_acf.tn
+	f = my_acf.fn
 
 Methods
 -------
@@ -33,16 +74,56 @@ Methods
 
 \
 
-        	Computes 2D ACF of intensity vs t and v where optimal sampling of t and v is provided with the output ACF.
+		Computes the 2D ACF of intensity vs time and frequency lag, implementing the integrals in Appendix A of Rickett, Coles et al. (2014). This is called automatically on construction of an ``ACF`` object, and populates ``self.acf``, ``self.tn`` (time-lag axis), ``self.fn`` (frequency-lag axis), ``self.snp`` (spatial-lag axis of the electric-field ACF), and ``self.acf_efield`` (ACF of the electric field).
 
-		**Parameters:** 
-				*   **plot** (`bool, optional`) - plot the simulated ACF
+		**Parameters:**
+				*   **plot** (`bool, optional`) - plot the resulting ACF after it is computed.
 
 .. raw:: html
 
-	<code class="descname">plot_acf</code><span class="sig-paren">(</span><em></em><span class="sig-paren">)</span>
+	<code class="descname">plot_acf</code><span class="sig-paren">(</span><em>display=True, contour=True, filled=False</em><span class="sig-paren">)</span>
 
 \
 
-        	Plot the simulated ACF
+		Plot the theoretical 2D ACF of intensity vs time and frequency lag. Requires ``calc_acf`` to have been run first.
 
+		**Parameters:**
+				*   **display** (`bool, optional`) - if True, set the plot title and show the plot immediately.
+				*   **contour** (`bool, optional`) - if True and ``filled`` is False, overlay black contours at ``amp * [0.2, 0.4, 0.6, 0.8]``.
+				*   **filled** (`bool, optional`) - if True, plot filled contours instead of a pcolormesh.
+
+.. raw:: html
+
+	<code class="descname">plot_acf_efield</code><span class="sig-paren">(</span><em>display=True</em><span class="sig-paren">)</span>
+
+\
+
+		Plot the ACF of the electric field vs spatial lag. Requires ``calc_acf`` to have been run first.
+
+		**Parameters:**
+				*   **display** (`bool, optional`) - if True, show the plot immediately.
+
+.. raw:: html
+
+	<code class="descname">calc_sspec</code><span class="sig-paren">(</span><em>window='hanning', window_frac=1</em><span class="sig-paren">)</span>
+
+\
+
+		Compute the secondary spectrum from the ACF, applying a 2D window before taking the 2D Fourier transform to reduce edge effects. Populates ``self.sspec`` (in dB).
+
+		**Parameters:**
+				*   **window** (`str, optional`) - name of the window function to apply along each axis before transforming, e.g. ``'hanning'`` (default), ``'hamming'``, ``'blackman'``, or ``'bartlett'``.
+				*   **window_frac** (`float, optional`) - fraction of each axis over which the window is applied.
+
+.. raw:: html
+
+	<code class="descname">plot_sspec</code><span class="sig-paren">(</span><em>display=True, vmin=None, vmax=None</em><span class="sig-paren">)</span>
+
+\
+
+		Plot the secondary spectrum vs time and frequency lag. Computes the secondary spectrum first via ``calc_sspec`` (with its default window) if it has not already been computed.
+
+		**Parameters:**
+				*   **display** (`bool, optional`) - if True, set the plot title and show the plot immediately.
+				*   **vmin** (`float or None, optional`) - minimum of the colour scale, in dB. If None, defaults to 3 dB below the median of the (finite, non-zero) secondary spectrum.
+				*   **vmax** (`float or None, optional`) - maximum of the colour scale, in dB. If None, defaults to 3 dB below the maximum of the (finite, non-zero) secondary spectrum.

--- a/docs/source/dynspec.rst
+++ b/docs/source/dynspec.rst
@@ -1,35 +1,141 @@
 Dynspec class
 =============
 
-Note: documentation is currently being developed by a student. In the meantime, please email Daniel for any questions on usage: dreardon@swin.edu.au
+The ``Dynspec`` class, found in the ``dynspec`` module, is the main entry point
+for processing and analysing observed pulsar dynamic spectra. It supports
+loading dynamic spectra from disk or from a simulation, cleaning and
+normalising them, computing autocorrelation functions (ACFs) and secondary
+spectra, measuring scintillation arcs, and estimating scintillation parameters.
 
-This will serve as a list of features available within the Dynspec class, in dynspec.py
+A full, runnable walkthrough is provided in the ``arc_modelling`` example
+notebook in ``scintools/examples``. The sections below summarise the most
+commonly used features.
 
 Importing dynamic spectra
 -------------------------
 
-A Dynspec object can be loaded from a `psrflux`-format dynamic spectrum, a simulation object, or ...
+A ``Dynspec`` object is most commonly loaded from a `psrflux`-format dynamic
+spectrum file::
 
-blah blah this is how you do things
+    from scintools.dynspec import Dynspec
 
+    dyn = Dynspec(filename="J0437-4715.dynspec", process=False)
+
+Setting ``process=False`` loads the data without running the default
+processing chain, so that each processing step can be applied manually. Pass
+``verbose=False`` to suppress progress output.
+
+A ``Dynspec`` object can also be built from a :doc:`Simulation <simulation>`
+object, or from an in-memory flux array via the ``BasicDyn`` helper::
+
+    dyn = Dynspec(dyn=my_sim)           # from a scint_sim.Simulation object
+    dyn = Dynspec(dyn=BasicDyn(...))    # from arrays of flux, times, freqs
+
+Multiple observations can be concatenated in time by adding ``Dynspec``
+objects together::
+
+    dyn_tot = dyn1 + dyn2
 
 Basic plotting
 --------------
 
-To view the dynamic spectrum, use 
+To view the dynamic spectrum::
 
     dyn.plot_dyn()
+
+Pass ``lamsteps=True`` to plot against wavelength rather than frequency (after
+scaling, see `Processing`_). The ACF and secondary spectrum can be plotted
+directly with::
+
+    dyn.plot_acf()
+    dyn.plot_sspec()
 
 Processing
 ----------
 
-the dynamic spectrum can be cleaned, cropped, normalised, and resampled in several ways
+The dynamic spectrum can be cleaned, cropped, normalised and resampled in
+several ways. A typical processing chain is::
 
+    dyn.trim_edges()     # remove empty channels/subints from the edges
+    dyn.refill()         # interpolate over gaps (e.g. zapped RFI)
+    dyn.correct_dyn()    # normalise out bandpass and time-variable gain
+    dyn.scale_dyn()      # rescale the frequency axis to wavelength (lambda)
+
+Other useful processing methods include:
+
+    * ``crop_dyn(fmin, fmax, tmin, tmax)`` - crop the dynamic spectrum in
+      frequency and/or time.
+    * ``refill(method='linear')`` / ``refill(method='mean')`` - choose the
+      interpolation method used to fill gaps.
+    * ``zap()`` - flag outlying pixels.
+
+For example, to combine several observations into a single long dynamic
+spectrum, each observation is trimmed, refilled and corrected before being
+added::
+
+    dyn_tot = Dynspec(filename=dyn_files[0], verbose=False)
+    dyn_tot.trim_edges()
+    dyn_tot.refill()
+    dyn_tot.correct_dyn()
+    for dyn_file in dyn_files[1:]:
+        dyn_new = Dynspec(filename=dyn_file, verbose=False)
+        dyn_new.trim_edges()
+        dyn_new.refill(method='linear')
+        dyn_new.correct_dyn()
+        dyn_tot += dyn_new
 
 Secondary spectra
 -----------------
 
-Calculation of the secondary spectrum. Includes pre-whitening and post-darkening by default ....
+The secondary spectrum is the two-dimensional power spectrum of the dynamic
+spectrum. It is computed with::
 
+    dyn.calc_sspec()
+    dyn.plot_sspec(lamsteps=True)
 
-arcs are cool
+Pre-whitening and post-darkening are applied by default. Passing
+``plot=True`` to ``calc_sspec`` computes and plots in a single step.
+
+Measuring scintillation arcs
+----------------------------
+
+Scintillation arcs appear as parabolic features in the secondary spectrum, and
+their curvature encodes the geometry and velocity of the scattering screen.
+The arc curvature is measured with ``fit_arc``::
+
+    dyn.fit_arc(
+        lamsteps=True,
+        plot=True,
+        etamin=2,
+        etamax=400,
+        delmax=1,
+        numsteps=1e3,
+        nsmooth=7,
+        startbin=2,
+    )
+
+The fitted curvature and its uncertainty are stored on the object::
+
+    print("Curvature:", dyn.betaeta)
+    print("Uncertainty:", dyn.betaetaerr)
+
+The fitted arc can be overlaid on the secondary spectrum::
+
+    dyn.plot_sspec(lamsteps=True, plotarc=True)
+
+The secondary spectrum can also be normalised about the fitted arc curvature
+with ``norm_sspec``::
+
+    dyn.norm_sspec(lamsteps=True, plot=True, delmax=0.3, cutmid=3, startbin=5)
+
+Scintillation parameters
+------------------------
+
+Scintillation timescale, decorrelation bandwidth and related parameters are
+estimated from the ACF with ``get_scint_params``::
+
+    dyn.get_scint_params(method="acf2d_approx", plot=True)
+
+The measured parameters (e.g. the scintillation timescale ``dyn.tau`` and
+decorrelation bandwidth ``dyn.dnu``) are stored as attributes on the object
+for downstream modelling.

--- a/docs/source/scint_models.rst
+++ b/docs/source/scint_models.rst
@@ -3,6 +3,35 @@ scint_models module
 
 The ``scint_models`` module contains various functions for modelling and fitting scintillation data.
 
+Fitting
+-------
+
+.. raw:: html
+
+	<code class="descname">fitter</code><span class="sig-paren">(</span><em>model, params, args, mcmc=False, pos=None, nwalkers=100, steps=1000, burn=0.2, progress=True, workers=1, nan_policy='raise', max_nfev=None, thin=10, is_weighted=True</em><span class="sig-paren">)</span>
+
+\
+
+		Common entry point for fitting one of the residual-returning models in this module using ``lmfit``. Wraps `model` and `params` in an ``lmfit`` ``Minimizer`` and either performs a least-squares minimisation, or (if ``mcmc=True``) runs the ``emcee`` MCMC sampler.
+
+		**Parameters:**
+				*   **model** (`callable`) - a model function from this module (e.g. ``tau_acf_model``, ``scint_acf_model``, ``scint_acf_model_2d_approx``, ``powerspectrum_model``) that takes ``params`` followed by the contents of `args` and returns the (weighted) residuals between data and model.
+				*   **params** (`lmfit Parameters() object`) - initial/starting parameters for the fit.
+				*   **args** (`tuple`) - extra positional arguments passed to `model` after `params` (typically some combination of ``xdata``, ``ydata``, and ``weights``).
+				*   **mcmc** (`bool`, optional) - if True, sample the posterior with ``emcee`` instead of doing a least-squares fit. The default is False.
+				*   **pos** (`array-like`, optional) - initial walker positions for ``emcee`` (only used if `mcmc` is True). The default is None.
+				*   **nwalkers** (`int`, optional) - number of ``emcee`` walkers (only used if `mcmc` is True). The default is 100.
+				*   **steps** (`int`, optional) - number of ``emcee`` steps to run (only used if `mcmc` is True). The default is 1000.
+				*   **burn** (`float`, optional) - fraction of `steps` to discard as burn-in (only used if `mcmc` is True). The default is 0.2.
+				*   **progress** (`bool`, optional) - whether ``emcee`` prints a progress bar (only used if `mcmc` is True). The default is True.
+				*   **workers** (`int`, optional) - number of parallel workers for ``emcee`` (only used if `mcmc` is True). The default is 1.
+				*   **nan_policy** (`str`, optional) - how ``lmfit`` should handle NaNs in the residuals for the least-squares fit (only used if `mcmc` is False). The default is 'raise'.
+				*   **max_nfev** (`int`, optional) - maximum number of function evaluations for the least-squares fit (only used if `mcmc` is False). The default is None.
+				*   **thin** (`int`, optional) - only accept every `thin`-th ``emcee`` sample (only used if `mcmc` is True). The default is 10.
+				*   **is_weighted** (`bool`, optional) - whether the residuals returned by `model` are already weighted (only used if `mcmc` is True). The default is True.
+		**Returns:**
+				*   The ``lmfit`` fit result object (``MinimizerResult``) returned by ``Minimizer.minimize()`` or ``Minimizer.emcee()``.
+
 ACF fitting
 -----------
 
@@ -80,7 +109,7 @@ ACF fitting
 		Models an analytical 2D ACF using the ``scint_sim`` ``ACF`` class. This method is significantly slower than ``scint_acf_model_2d_approx()``.
 
 		**Parameters:** 
-				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit amplitude ('amp'), timescale at :math:`1/e` width ('tau'), decorrelation bandwidth at half power ('dnu'), index of exponential function ('alpha', 2 is Gaussian, 5/3 is Kolmogorov), white-noise spike ('wn'), phase gradient in x and y ('phasegrad_x', 'phasegrad_y'), axial ratio of anisotropy ('ar'), orientation of anisotropy relative to y ('psi'), and effective velocity in x and y ('v_ra', 'v_dec'), as well as the total bandwidth of the observation ('bw'), total observation time ('tobs'), and half the number of sub-integrations and channels in the ACF ('nt', 'nf').
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit timescale at :math:`1/e` width ('tau'), decorrelation bandwidth at half power ('dnu'), index of exponential function ('alpha', 2 is Gaussian, 5/3 is Kolmogorov), axial ratio of anisotropy ('ar'), orientation of anisotropy ('psi'), phase gradient ('phasegrad'), rotation of the phase gradient ('theta'), and amplitude ('amp'), as well as the total observation time ('tobs'), total bandwidth of the observation ('bw'), and the number of sub-integrations and channels used to build the model ACF ('nt', 'nf').
 				*   **ydata** (`numpy 1D array`) - ACF cropped symmetrically around its center to a desired range.
 				*   **weights** (`numpy 1D array`) - weights of the data.
 		**Returns:** 
@@ -88,35 +117,33 @@ ACF fitting
 
 .. raw:: html
 
-	<code class="descname">tau_sspec_model</code><span class="sig-paren">(</span><em>params, xdata, ydata, weights</em><span class="sig-paren">)</span>
+	<code class="descname">tau_sspec_model</code><span class="sig-paren">(</span><em>params, xdata, ydata</em><span class="sig-paren">)</span>
 
 \
 
 		Models a 1D cut through the center of the ACF along the time axis and applies a Fourier transform.
 
-		**Parameters:** 
-				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit amplitude ('amp'), timescale at :math:`1/e` width ('tau'), index of exponential function ('alpha', 2 is Gaussian, 5/3 is Kolmogorov), and white-noise spike ('wn').
+		**Parameters:**
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit amplitude ('amp'), timescale at :math:`1/e` width ('tau'), and index of exponential function ('alpha', 2 is Gaussian, 5/3 is Kolmogorov).
 				*   **xdata** (`numpy 1D array`) - time of sub-integrations from the center of the ACF to the maximum time.
 				*   **ydata** (`numpy 1D array`) - profile from secondary spectrum corresponding to the ACF to model summed along all columns (all :math:`f_t`).
-				*   **weights** (`numpy 1D array`) - weights of the data
-		**Returns:** 
-				*   Weighted residual of model and data
+		**Returns:**
+				*   Residual of model and data, weighted by the model itself
 
 .. raw:: html
 
-	<code class="descname">dnu_sspec_model</code><span class="sig-paren">(</span><em>params, xdata, ydata, weights</em><span class="sig-paren">)</span>
+	<code class="descname">dnu_sspec_model</code><span class="sig-paren">(</span><em>params, xdata, ydata</em><span class="sig-paren">)</span>
 
 \
 
 		Models a 1D cut through the center of the ACF along the frequency axis and applies a Fourier tranform.
 
-		**Parameters:** 
-				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit amplitude ('amp'), decorrelation bandwidth at half power ('tau'), index of exponential function ('alpha', 2 is Gaussian, 5/3 is Kolmogorov), and white-noise spike ('wn').
+		**Parameters:**
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit amplitude ('amp') and decorrelation bandwidth at half power ('dnu').
 				*   **xdata** (`numpy 1D array`) - frequency of the channels from the center of the ACF to the maximum frequency.
 				*   **ydata** (`numpy 1D array`) - profile from secondary spectrum corresponding to the ACF to model summed along all rows (all :math:`f_\tau` or :math:`f_\lambda`).
-				*   **weights** (`numpy 1D array`) - weights of the data.
-		**Returns:** 
-				*   Weighted residual of model and data
+		**Returns:**
+				*   Residual of model and data, weighted by the model itself
 
 .. raw:: html
 
@@ -136,6 +163,21 @@ ACF fitting
 
 Secondary spectrum fitting
 --------------------------
+
+.. raw:: html
+
+	<code class="descname">powerspectrum_model</code><span class="sig-paren">(</span><em>params, xdata, ydata</em><span class="sig-paren">)</span>
+
+\
+
+		Models a red-noise power spectrum (e.g. of the frequency-averaged secondary spectrum vs :math:`\sqrt{\eta}`) as a power law plus a white-noise floor, and returns the residuals.
+
+		**Parameters:**
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the white-noise level ('wn'), power-law amplitude ('amp'), and power-law index ('alpha').
+				*   **xdata** (`numpy 1D array`) - independent variable (e.g. square root of delay).
+				*   **ydata** (`numpy 1D array`) - power spectrum values corresponding to `xdata`.
+		**Returns:**
+				*   Residual of model and data (not multiplied by weights)
 
 .. raw:: html
 
@@ -187,39 +229,77 @@ Secondary spectrum fitting
 
 .. raw:: html
 
-	<code class="descname">arc_curvature</code><span class="sig-paren">(</span><em>params, ydata, weights, true_anomaly, vearth_ra, vearth_dec</em><span class="sig-paren">)</span>
+	<code class="descname">arc_curvature</code><span class="sig-paren">(</span><em>params, ydata, weights, true_anomaly, vearth_ra, vearth_dec, mjd=None, model_only=False, return_veff=False</em><span class="sig-paren">)</span>
 
 \
 
-		Models the arc curvature and returns the residuals.
+		Models the arc curvature and returns the residuals (or, if ``model_only=True``, the model curvature itself).
 
-		**Parameters:** 
-				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing current best-fit values for the distance to the pulsar ('d'), the fractional screen distance ('s'), and optionally the ISM velocity in RA and dec ('vism_ra', 'vism_dec').
+		**Parameters:**
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing current best-fit values for the distance to the pulsar in kpc ('d'), the fractional screen distance ('s'), plus the parameters required by ``effective_velocity_annual``, and optionally an anisotropy model flag ('nmodel'), anisotropy angle ('zeta'), and the ISM velocity in RA and dec ('vism_ra', 'vism_dec') or, for the anisotropic case, along ``zeta`` ('vism_zeta'). The deprecated parameter names 'psi' and 'vism_psi' are no longer supported.
 				*   **ydata** (`numpy 1D array`) - arc curvature data.
 				*   **weights** (`numpy 1D array`) - weights of the data.
 				*   **true_anomaly** (`numpy 1D array`) - true anolmalies corresponding to the data.
 				*   **vearth_ra** (`numpy 1D array`) - Earth velocity in RA corresponding to the data.
 				*   **vearth_dec** (`numpy 1D array`) - Earth velocity in dec corresponding to the data.
-		**Returns:** 
-				*   Weighted residual of model and data
+				*   **mjd** (`numpy 1D array`, optional) - MJDs corresponding to the data, used for the 'OMDOT' correction. The default is None.
+				*   **model_only** (`bool`, optional) - if True, return the model curvature instead of the residuals. The default is False.
+				*   **return_veff** (`bool`, optional) - if True (and ``model_only=True``), also return the ISM-subtracted effective velocity in RA and dec. The default is False.
+		**Returns:**
+				*   Weighted residual of model and data (or the model curvature, and optionally the effective velocity components, if ``model_only=True``)
+
+.. raw:: html
+
+	<code class="descname">arc_weak</code><span class="sig-paren">(</span><em>ftn, ar=1, psi=0, alpha=11/3</em><span class="sig-paren">)</span>
+
+\
+
+		Models the 1D weak-scattering scintillation arc Doppler profile (power vs normalised Doppler frequency), for a possibly anisotropic scattering screen.
+
+		**Parameters:**
+				*   **ftn** (`numpy 1D array`) - the normalised Doppler frequency (x-axis), where ``ftn = 1`` is the arc.
+				*   **ar** (`float`, optional) - anisotropy axial ratio. The default is 1 (isotropic).
+				*   **psi** (`float`, optional) - orientation angle of the anisotropy, in degrees. The default is 0.
+				*   **alpha** (`float`, optional) - index of the turbulence spectrum. The default is 11/3 (Kolmogorov).
+		**Returns:**
+				*   The model Doppler profile
+
+.. raw:: html
+
+	<code class="descname">arc_weak_2d</code><span class="sig-paren">(</span><em>fdop, tdel, eta=1, ar=1, psi=0, alpha=11/3</em><span class="sig-paren">)</span>
+
+\
+
+		Models the 2D weak-scattering secondary spectrum along a scintillation arc, for a possibly anisotropic scattering screen.
+
+		**Parameters:**
+				*   **fdop** (`numpy 1D array`) - the Doppler frequency (x-axis) coordinates of the model secondary spectrum.
+				*   **tdel** (`numpy 1D array`) - the delay (y-axis) coordinates of the model secondary spectrum.
+				*   **eta** (`float`, optional) - arc curvature. The default is 1.
+				*   **ar** (`float`, optional) - anisotropy axial ratio. The default is 1 (isotropic).
+				*   **psi** (`float`, optional) - orientation angle of the anisotropy, in degrees. The default is 0.
+				*   **alpha** (`float`, optional) - index of the turbulence spectrum. The default is 11/3 (Kolmogorov). Currently unused by the model, which always uses a fixed exponent of -11/6.
+		**Returns:**
+				*   The model secondary spectrum (2D array)
 
 Velocity models
 ---------------
 
 .. raw:: html
 
-	<code class="descname">effective_velocity_annual</code><span class="sig-paren">(</span><em>params, true_anomaly, vearth_ra, vearth_dec</em><span class="sig-paren">)</span>
+	<code class="descname">effective_velocity_annual</code><span class="sig-paren">(</span><em>params, true_anomaly, vearth_ra, vearth_dec, mjd=None</em><span class="sig-paren">)</span>
 
 \
 
-		Models the arc curvature and returns the residuals.
+		Computes the effective velocity including annual (Earth orbital and proper motion) and pulsar orbital terms. Does NOT include the IISM velocity, but the returned effective velocity is expressed in the IISM frame.
 
-		**Parameters:** 
-				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the pulsar's projected semi-major axis in lt-s ('A1'), orbital period in days ('PB'), orbital eccentricity ('ECC'), longitude of periastron in degrees ('OM'), inclination in degrees ('KIN'), longitude of ascending node in degrees ('KOM'), and optionally the proper motion in RA and dec ('PMRA', 'PMDEC'), as well as the distance to the pulsar ('d') and the fractional screen distance ('s').
+		**Parameters:**
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing, for a binary pulsar, the projected semi-major axis in lt-s ('A1'), orbital period in days ('PB'), orbital eccentricity ('ECC'), longitude of periastron in degrees ('OM'), inclination via one of 'KIN' (degrees), 'COSI', or 'SINI', and optionally an inclination-sense flag ('sense') and periastron-advance rate in deg/yr ('OMDOT', requires 'T0' and ``mjd``); also, optionally, the proper motion in RA and dec ('PMRA', 'PMDEC'), and always the longitude of ascending node in degrees ('KOM'), the distance to the pulsar in kpc ('d'), and the fractional screen distance ('s').
 				*   **true_anomaly** (`numpy 1D array`) - true anolmalies to compute over.
 				*   **vearth_ra** (`numpy 1D array`) - Earth velocity in RA to compute over.
 				*   **vearth_dec** (`numpy 1D array`) - Earth velocity in dec to compute over.
-		**Returns:** 
+				*   **mjd** (`numpy 1D array`, optional) - MJDs corresponding to ``true_anomaly``, used for the 'OMDOT' correction. The default is None.
+		**Returns:**
 				*   Effective velocity in RA
 				*   Effective velocity in dec
 				*   Pulsar velocity in RA
@@ -227,17 +307,20 @@ Velocity models
 
 .. raw:: html
 
-	<code class="descname">thin_screen</code><span class="sig-paren">(</span><em>params, xdata, ydata, weights</em><span class="sig-paren">)</span>
+	<code class="descname">veff_thin_screen</code><span class="sig-paren">(</span><em>params, ydata, weights, true_anomaly, vearth_ra, vearth_dec, mjd=None</em><span class="sig-paren">)</span>
 
 \
 
-		Models the thin screen effective velocity and returns the residuals.
+		Models the effective velocity implied by a thin-screen scattering geometry and returns the residuals. Uses Eq. 4 from Rickett et al. (2014) for the anisotropy coefficients.
 
-		**Parameters:** 
-				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object.
-				*   **xdata** (`numpy 1D array`) - 
-				*   **ydata** (`numpy 1D array`) - screen effective velocity data
+		**Parameters:**
+				*   **params** (`lmfit Parameters() object`) - ``lmfit`` ``Parameters()`` object containing the current best-fit fractional screen distance ('s') and pulsar distance in kpc ('d'), plus the parameters required by ``effective_velocity_annual``, and optionally a scaling factor ('kappa', default 1), an anisotropy model flag ('nmodel'), and, for the anisotropic case, an axial ratio parameter ('R') and anisotropy angle in degrees ('psi'). ISM velocity in RA and dec ('vism_ra', 'vism_dec') may also be given and is subtracted from the effective velocity.
+				*   **ydata** (`numpy 1D array`) - measured effective velocity data.
 				*   **weights** (`numpy 1D array`) - weights of the data.
-		**Returns:** 
+				*   **true_anomaly** (`numpy 1D array`) - true anolmalies corresponding to the data.
+				*   **vearth_ra** (`numpy 1D array`) - Earth velocity in RA corresponding to the data.
+				*   **vearth_dec** (`numpy 1D array`) - Earth velocity in dec corresponding to the data.
+				*   **mjd** (`numpy 1D array`, optional) - MJDs corresponding to the data, used for the 'OMDOT' correction. The default is None.
+		**Returns:**
 				*   Weighted residual of model and data
 

--- a/docs/source/scint_utils.rst
+++ b/docs/source/scint_utils.rst
@@ -5,33 +5,54 @@ Astrophysical modelling
 
 .. raw:: html
 
-	<code class="descname">get_ssb_delay</code><span class="sig-paren">(</span><em>mjds, raj, decj</em><span class="sig-paren">)</span>
+	<code class="descname">get_ssb_delay</code><span class="sig-paren">(</span><em>mjds, raj, decj, message=True</em><span class="sig-paren">)</span>
 
 \
 
 		Get Romer delay to Solar System Barycentre (SSB) for correction of site arrival times to barycentric.
 
-		**Parameters:** 
+		**Parameters:**
 				*   **mjds** (`numpy 1D array`) - list of modified Julian dates to calculate over
-				*   **raj** (`float`) - right ascension (J2000) of the pulsar in degrees
-				*   **decj** (`float`) - declination (J2000) of the pulsar in degrees
-		**Returns:** 
-				*   List of Romer delays
+				*   **raj** (`str`) - right ascension (J2000) of the pulsar, e.g. ``'hh:mm:ss'``
+				*   **decj** (`str`) - declination (J2000) of the pulsar, e.g. ``'dd:mm:ss'``
+				*   **message** (`bool, optional`) - if True, print a reminder that the returned delays should be added to site arrival times
+		**Returns:**
+				*   List of Romer delays, in seconds
 .. raw:: html
 
-	<code class="descname">get_earth_velocity</code><span class="sig-paren">(</span><em>mjds, raj, decj</em><span class="sig-paren">)</span>
+	<code class="descname">get_earth_velocity</code><span class="sig-paren">(</span><em>mjds, raj, decj, radial=False</em><span class="sig-paren">)</span>
 
 \
 
-		Calculates the component of Earth's velocity transverse to the line of sight, in RA and DEC
+		Calculates the component of Earth's velocity transverse to the line of sight, in RA and DEC. Optionally also returns the radial velocity.
 
-		**Parameters:** 
+		**Parameters:**
 				*   **mjds** (`numpy 1D array`) - list of modified Julian dates to calculate over
-				*   **raj** (`float`) - right ascension (J2000) of the pulsar in degrees
-				*   **decj** (`float`) - declination (J2000) of the pulsar in degrees
-		**Returns:** 
-				*   List of Earth velocities in RA
-				*   List of Earth velocities in dec
+				*   **raj** (`str`) - right ascension (J2000) of the pulsar, e.g. ``'hh:mm:ss'``
+				*   **decj** (`str`) - declination (J2000) of the pulsar, e.g. ``'dd:mm:ss'``
+				*   **radial** (`bool, optional`) - if True, also return Earth's radial velocity component
+		**Returns:**
+				*   List of Earth velocities in RA, in km/s
+				*   List of Earth velocities in dec, in km/s
+				*   List of Earth radial velocities, in km/s (only if ``radial=True``)
+
+.. raw:: html
+
+	<code class="descname">make_lsr</code><span class="sig-paren">(</span><em>d, raj, decj, pmra, pmdec, vr=0</em><span class="sig-paren">)</span>
+
+\
+
+		Converts a pulsar's barycentric proper motion and radial velocity to proper motion in the Local Standard of Rest (LSR) frame, using the IAU standard solar motion with respect to the LSR.
+
+		**Parameters:**
+				*   **d** (`float`) - distance to the pulsar, in kpc
+				*   **raj** (`str`) - right ascension (J2000) of the pulsar, e.g. ``'hh:mm:ss'``
+				*   **decj** (`str`) - declination (J2000) of the pulsar, e.g. ``'dd:mm:ss'``
+				*   **pmra** (`float`) - proper motion in right ascension (``pm_ra_cosdec``), in mas/yr
+				*   **pmdec** (`float`) - proper motion in declination, in mas/yr
+				*   **vr** (`float, optional`) - radial velocity, in km/s. The default is 0.
+		**Returns:**
+				*   Proper motion components (RA, Dec) of the pulsar in the LSR frame, in mas/yr
 
 .. raw:: html
 
@@ -44,8 +65,72 @@ Astrophysical modelling
 		**Parameters:** 
 				*   **mjds** (`numpy 1D array`) - list of modified Julian dates to calculate over
 				*   **pars** (`dict`) - parameter file containing the orbital eccentricity ('ECC'), binary period ('PB'), MJD of binary period measurement ('T0'), and binary period derivative, :math:`\dot P` ('PBDOT').
-		**Returns:** 
+		**Returns:**
 				*   List of true anomalies
+
+.. raw:: html
+
+	<code class="descname">get_binphase</code><span class="sig-paren">(</span><em>mjds, pars</em><span class="sig-paren">)</span>
+
+\
+
+		Calculates binary phase (true anomaly plus argument of periastron) for an array of barycentric MJDs and a parameter dictionary.
+
+		**Parameters:**
+				*   **mjds** (`numpy 1D array`) - list of modified Julian dates to calculate over
+				*   **pars** (`dict`) - parameter dictionary as used by ``get_true_anomaly()``, plus (for non-ELL1 models) the argument of periastron ``OM`` (degrees) and optionally its derivative ``OMDOT`` (deg/yr)
+		**Returns:**
+				*   List of binary phases, in radians
+
+.. raw:: html
+
+	<code class="descname">differential_velocity</code><span class="sig-paren">(</span><em>params, sun_velocity=220, screen_velocity=220, radius=8</em><span class="sig-paren">)</span>
+
+\
+
+		Approximates the differential velocity between the scattering screen and the Sun assuming zero-inclination circular galactic orbits. Useful for determining the intrinsic ISM velocity.
+
+		**Parameters:**
+				*   **params** (`dict`) - parameters containing the pulsar RAJ and DECJ, pulsar distance ``d``, screen fractional distance ``s``, and anisotropy angle ``psi``
+				*   **sun_velocity** (`float, optional`) - orbital speed of the Sun in km/s. The default is 220.
+				*   **screen_velocity** (`float, optional`) - orbital speed of the scattering screen in km/s, assuming a flat galactic rotation curve. The default is 220.
+				*   **radius** (`float, optional`) - radius of the Sun's orbit about the galactic center, in kpc. The default is 8.
+		**Returns:**
+				*   RA component of the differential velocity, in km/s
+				*   Dec component of the differential velocity, in km/s
+
+.. raw:: html
+
+	<code class="descname">scint_velocity</code><span class="sig-paren">(</span><em>params, dnu, tau, freq, dnuerr=None, tauerr=None, a=2.53e4</em><span class="sig-paren">)</span>
+
+\
+
+		Calculate the scintillation velocity from the ACF scintillation bandwidth and timescale, using the thin-screen scintillation velocity equation.
+
+		**Parameters:**
+				*   **params** (`dict or lmfit Parameters, optional`) - parameters containing the pulsar distance ``d`` and screen fractional distance ``s`` (and their uncertainties). If None, ``a`` is used directly as the thin-screen coefficient.
+				*   **dnu** (`float or numpy array`) - scintillation bandwidth, in MHz
+				*   **tau** (`float or numpy array`) - scintillation timescale, in seconds
+				*   **freq** (`float or numpy array`) - observing frequency, in MHz
+				*   **dnuerr** (`float or numpy array, optional`) - uncertainty on ``dnu``
+				*   **tauerr** (`float or numpy array, optional`) - uncertainty on ``tau``
+				*   **a** (`float, optional`) - fixed thin-screen coefficient used when ``params`` is None. The default is 2.53e4.
+		**Returns:**
+				*   Scintillation velocity, in km/s
+				*   Uncertainty on the scintillation velocity, in km/s (only if ``dnuerr`` and ``tauerr`` are both given)
+
+.. raw:: html
+
+	<code class="descname">acor</code><span class="sig-paren">(</span><em>arr</em><span class="sig-paren">)</span>
+
+\
+
+		Calculates the characteristic (50%) autocorrelation length of an array, e.g. a time series.
+
+		**Parameters:**
+				*   **arr** (`array`) - array of numbers, e.g. a time series
+		**Returns:**
+				*   Characteristic (50%) autocorrelation length (int)
 
 Reading and writing data
 ------------------------
@@ -83,10 +168,35 @@ Reading and writing data
 
 		Reads a CSV results file written by `write_results()`
 
-		**Parameters:** 
+		**Parameters:**
 				*   **filename** (`str`) - path of the file to read from
-		**Returns:** 
+		**Returns:**
 				*   Dictionary of parameters from file
+
+.. raw:: html
+
+	<code class="descname">search_and_replace</code><span class="sig-paren">(</span><em>filename, search, replace</em><span class="sig-paren">)</span>
+
+\
+
+		Reads a text file, replaces all occurrences of one substring with another, and overwrites the file with the result.
+
+		**Parameters:**
+				*   **filename** (`str`) - path to the text file to edit in place
+				*   **search** (`str`) - substring to search for
+				*   **replace** (`str`) - substring to substitute in place of ``search``
+
+.. raw:: html
+
+	<code class="descname">save_fits</code><span class="sig-paren">(</span><em>filename, dyn</em><span class="sig-paren">)</span>
+
+\
+
+		Saves a dynamic spectrum to a FITS file as the primary HDU.
+
+		**Parameters:**
+				*   **filename** (`str`) - path of the FITS file to write (must not already exist)
+				*   **dyn** (`Dynspec object`) - Dynspec object whose ``dyn`` array is written to the FITS file
 
 .. raw:: html
 
@@ -134,19 +244,19 @@ Other utilities
 
 .. raw:: html
 
-	<code class="descname">clean_archive</code><span class="sig-paren">(</span><em>archive, template=None, bandwagon=0.99, channel_threshold=7, subint_threshold=5, output_directory=None</em><span class="sig-paren">)</span>
+	<code class="descname">clean_archive</code><span class="sig-paren">(</span><em>archive, template=None, bandwagon=0.99, channel_threshold=5, subint_threshold=5, output_directory=None</em><span class="sig-paren">)</span>
 
 \
 
-		Cleans a psrchive archive object using ``coast_guard``.
+		Cleans a psrchive archive using the ``coast_guard`` ``surgical`` and ``bandwagon`` cleaners, then unloads the cleaned archive to disk with a ``.clean`` extension.
 
-		**Parameters:** 
-				*   **archive** (`psarchive archive object`) - psarchive archive
-				*   **template** (`str, optional`) - 
-				*   **bandwagon** (`float, optional`) - bandwagon value
-				*   **channel_threshold** (`float, optional`) - channel threshold
-				*   **subint_threshold** (`float, optional`) - sub-integration threshold
-				*   **output_directory** (`str`) - directory to output the cleaned archive
+		**Parameters:**
+				*   **archive** (`str or psrchive archive object`) - path to, or already-loaded psrchive archive object, to be cleaned
+				*   **template** (`str, optional`) - path to a template profile. Currently unused by this function, reserved for future use with the cleaners.
+				*   **bandwagon** (`float, optional`) - ``badchantol`` value passed to the ``bandwagon`` cleaner. The default is 0.99.
+				*   **channel_threshold** (`float, optional`) - ``chanthresh`` (sigma threshold for flagging channels) passed to the ``surgical`` cleaner. The default is 5.
+				*   **subint_threshold** (`float, optional`) - ``subintthresh`` (sigma threshold for flagging subintegrations) passed to the ``surgical`` cleaner. The default is 5.
+				*   **output_directory** (`str, optional`) - directory to output the cleaned archive. If None, writes alongside the input archive.
 
 .. raw:: html
 
@@ -187,10 +297,10 @@ Other utilities
 
 		Take SVD of a dynamic spectrum, divide by the largest N modes
 
-		**Parameters:** 
-				*   **arr** (`numpy 2D array`) - input dynamic spectrum
-				*   **nmodes** (`int, optional`) - number of singular values to compute up to.
-		**Returns:** 
+		**Parameters:**
+				*   **arr** (`numpy 2D array`) - time/freq visibility matrix (input dynamic spectrum)
+				*   **nmodes** (`int, optional`) - number of leading singular values (modes) to keep when constructing the model; higher-order modes are zeroed. The default is 1.
+		**Returns:**
 				*   Array divided by absolute value of SVD model
 				*   SVD model
 
@@ -200,39 +310,203 @@ Other utilities
 
 \
 
-		Creates a `psrflux`-format dynamic spectrum from an archive ``$ psrflux -s [template] -e dynspec [archive]``
+		Creates a `psrflux`-format dynamic spectrum from an archive ``$ psrflux -s [template] -e dynspec [archive]``. **Note:** this function is a placeholder for future functionality and is not yet implemented.
 
-		**Parameters:** 
-				*   **archive** (`psarchive archive object`) - psarchive archive
-				*   **template** (`str, optional`) - 
-				*   **phasebin** (`int, optional`) - 
-
-.. raw:: html
-
-	<code class="descname">remove_duplicates</code><span class="sig-paren">(</span><em>dyn_files</em><span class="sig-paren">)</span>
-
-\
-
-		Filters out dynamic spectra from simultaneous observations.
-
-		**Parameters:** 
-				*   **dyn_files** (`list or numpy 1D array or str`) - list of dynamic spectrum file paths
-
-		**Returns:** 
-				*   Filtered list of dynamic spectrum file paths
+		**Parameters:**
+				*   **archive** (`str or psrchive archive object`) - path to, or already-loaded psrchive archive object, to create the dynamic spectrum from
+				*   **template** (`str, optional`) - path to a template profile, passed to ``psrflux -s``
+				*   **phasebin** (`int, optional`) - number of pulse phase bins to integrate over when forming the dynamic spectrum. The default is 1.
 
 .. raw:: html
 
-	<code class="descname">make_pickle</code><span class="sig-paren">(</span><em>dyn, process=True, sspec=True, acf=True, lamsteps=True</em><span class="sig-paren">)</span>
+	<code class="descname">make_pickle</code><span class="sig-paren">(</span><em>obj, filepath</em><span class="sig-paren">)</span>
 
 \
 
-		Pickles a dynamic spectrum object.
+		Pickles ``obj`` to ``filepath``, writing in chunks so that this also works for objects whose pickled representation is larger than 2GB.
 
-		**Parameters:** 
-				*   **dyn** (`Dynspec object`) - dynamic spectrum Dynspec object.
-				*   **process** (`bool, optional`) - perform default processing. Involves trimming the edges, refilling, correction, and calculation of the ACF and secondary spectrum.
-				*   **sspec** (`numpy 2D array, optional`) - input secondary spectrum.
-				*   **acf** (`numpy 2D array, optional`) - input autocorrelation function.
-				*   **lamsteps** (`bool, optional`) - option to use wavelength steps instead of default frequency steps.
+		**Parameters:**
+				*   **obj** (`object`) - Python object to pickle (e.g. a Dynspec object)
+				*   **filepath** (`str`) - path of the file to write the pickle to
+
+.. raw:: html
+
+	<code class="descname">load_pickle</code><span class="sig-paren">(</span><em>filepath</em><span class="sig-paren">)</span>
+
+\
+
+		Loads a pickled object from ``filepath``, reading in chunks so that this also works for pickle files larger than 2GB. Counterpart to ``make_pickle()``.
+
+		**Parameters:**
+				*   **filepath** (`str`) - path of the pickle file to read
+		**Returns:**
+				*   The unpickled Python object
+
+.. raw:: html
+
+	<code class="descname">autocorr</code><span class="sig-paren">(</span><em>arr</em><span class="sig-paren">)</span>
+
+\
+
+		Does a slow (direct, nested-loop) calculation of the 2D autocorrelation of an input masked array.
+
+		**Parameters:**
+				*   **arr** (`numpy masked array`) - 2D masked array to autocorrelate
+		**Returns:**
+				*   2D autocorrelation of ``arr``, normalised so the maximum value is 1
+
+.. raw:: html
+
+	<code class="descname">cov_to_corr</code><span class="sig-paren">(</span><em>cov</em><span class="sig-paren">)</span>
+
+\
+
+		Calculates the correlation matrix from a covariance matrix.
+
+		**Parameters:**
+				*   **cov** (`numpy 2D array`) - covariance matrix
+		**Returns:**
+				*   Correlation matrix corresponding to ``cov``
+
+.. raw:: html
+
+	<code class="descname">difference</code><span class="sig-paren">(</span><em>x</em><span class="sig-paren">)</span>
+
+\
+
+		Unlike ``numpy.diff``, computes differences between the centres of neighbouring elements in ``x``, returning an array the same size as ``x``.
+
+		**Parameters:**
+				*   **x** (`array_like`) - input 1D array
+		**Returns:**
+				*   Array of centred differences, the same length as ``x``
+
+.. raw:: html
+
+	<code class="descname">mjd_to_year</code><span class="sig-paren">(</span><em>mjd</em><span class="sig-paren">)</span>
+
+\
+
+		Converts Modified Julian Date(s) to a decimal (Besselian) year.
+
+		**Parameters:**
+				*   **mjd** (`float or array_like`) - Modified Julian Date(s) to convert
+		**Returns:**
+				*   Decimal year(s) corresponding to ``mjd``
+
+.. raw:: html
+
+	<code class="descname">find_nearest</code><span class="sig-paren">(</span><em>arr, val</em><span class="sig-paren">)</span>
+
+\
+
+		Returns the index of an array (``arr``) that is nearest to value (``val``).
+
+		**Parameters:**
+				*   **arr** (`array_like`) - array to search
+				*   **val** (`float`) - value to find the nearest element to
+		**Returns:**
+				*   Index of the element of ``arr`` closest to ``val``
+
+.. raw:: html
+
+	<code class="descname">longest_run_of_zeros</code><span class="sig-paren">(</span><em>arr</em><span class="sig-paren">)</span>
+
+\
+
+		Finds the length of the longest run of consecutive zeros in an array.
+
+		**Parameters:**
+				*   **arr** (`array_like`) - input 1D array (or iterable) of numbers
+		**Returns:**
+				*   Length of the longest consecutive run of zero-valued elements in ``arr``
+
+.. raw:: html
+
+	<code class="descname">interp_nan_2d</code><span class="sig-paren">(</span><em>array, method='linear'</em><span class="sig-paren">)</span>
+
+\
+
+		Fills in NaN (and other invalid) values of a 2D array by interpolating from the surrounding valid pixels.
+
+		**Parameters:**
+				*   **array** (`array_like`) - 2D input array possibly containing NaN or otherwise invalid values
+				*   **method** (`str, optional`) - interpolation method (``'linear'``, ``'nearest'``, or ``'cubic'``). The default is ``'linear'``.
+		**Returns:**
+				*   2D array with invalid values filled in by interpolation
+
+.. raw:: html
+
+	<code class="descname">centres_to_edges</code><span class="sig-paren">(</span><em>arr</em><span class="sig-paren">)</span>
+
+\
+
+		Takes an array of pixel-centres, and returns an array of pixel-edges. Assumes the pixel-centres are evenly spaced.
+
+		**Parameters:**
+				*   **arr** (`array_like`) - 1D array of evenly-spaced pixel-centre values
+		**Returns:**
+				*   Array of pixel-edge values, one longer than ``arr``
+
+.. raw:: html
+
+	<code class="descname">get_window</code><span class="sig-paren">(</span><em>nt, nf, window='hanning', frac=0.1</em><span class="sig-paren">)</span>
+
+\
+
+		Returns tapering windows to apply along the time and frequency axes before computing an FFT.
+
+		**Parameters:**
+				*   **nt** (`int`) - length of the time axis
+				*   **nf** (`int`) - length of the frequency axis
+				*   **window** (`str, optional`) - window type: ``'hanning'``, ``'hamming'``, ``'blackman'``, or ``'bartlett'``. The default is ``'hanning'``.
+				*   **frac** (`float, optional`) - fraction of each axis length to taper at the edges. The default is 0.1.
+		**Returns:**
+				*   Tapering window of length ``nt``, for the time axis
+				*   Tapering window of length ``nf``, for the frequency axis
+
+.. raw:: html
+
+	<code class="descname">calculate_curvature_peak_probability</code><span class="sig-paren">(</span><em>power_data, noise_level, smooth=True, curvatures=None, log=False</em><span class="sig-paren">)</span>
+
+\
+
+		Calculates the (unnormalised) Gaussian probability distribution of the arc curvature "power vs curvature" profile, modelling the profile as a Gaussian peak at its maximum with standard deviation given by ``noise_level``.
+
+		**Parameters:**
+				*   **power_data** (`array_like`) - power (Doppler profile) as a function of curvature, for one or more observations
+				*   **noise_level** (`float or array_like`) - noise standard deviation of ``power_data``, used as the Gaussian width (and smoothing sigma if ``smooth=True``)
+				*   **smooth** (`bool, optional`) - if True, smooth ``power_data`` with a Gaussian filter of sigma ``noise_level`` before computing the probability. The default is True.
+				*   **curvatures** (`array_like, optional`) - curvature values corresponding to ``power_data``. Currently unused.
+				*   **log** (`bool, optional`) - if True, return the log-probability instead of the probability. The default is False.
+		**Returns:**
+				*   (Log-)probability distribution, same shape as ``power_data``
+
+.. raw:: html
+
+	<code class="descname">save_curvature_data</code><span class="sig-paren">(</span><em>dyn, filename=None</em><span class="sig-paren">)</span>
+
+\
+
+		Saves the "power vs curvature" arc-fitting data and noise level to a ``.npz`` file, for later use with ``calculate_curvature_peak_probability()`` or ``curvature_log_likelihood()``.
+
+		**Parameters:**
+				*   **dyn** (`Dynspec object`) - Dynspec object with arc-curvature fitting results (e.g. ``eta_array``, ``norm_sspec_avg``, and ``noise``)
+				*   **filename** (`str, optional`) - output file path. If None, defaults to ``dyn.name + 'curvature_data'``.
+
+.. raw:: html
+
+	<code class="descname">curvature_log_likelihood</code><span class="sig-paren">(</span><em>power, nfdop, noise, model_nfdop</em><span class="sig-paren">)</span>
+
+\
+
+		Calculates the log likelihood of a model prediction for ``nfdop`` by taking the likelihood function for each observation to be a probability density calculated from the doppler profile.
+
+		**Parameters:**
+				*   **power** (`array_like`) - doppler profile(s)
+				*   **nfdop** (`array_like`) - nfdop values for doppler profile(s)
+				*   **noise** (`float or array_like`) - noise value for each profile
+				*   **model_nfdop** (`float or array_like`) - model prediction for nfdop for each profile
+		**Returns:**
+				*   Log likelihood of the input data (float)
 

--- a/docs/source/simulation.rst
+++ b/docs/source/simulation.rst
@@ -1,22 +1,143 @@
 Simulation class
 ================
 
-This will serve as a list of features available within the Simulation class, scint_sim.py
+The ``Simulation`` class, found in the ``scint_sim`` module, is a wave-optics
+simulator of a thin scattering screen. It generates a random phase screen with
+a given power-law structure function and anisotropy, propagates it through the
+Fresnel diffraction integral to obtain the electric field and intensity as a
+function of observer position and frequency, and packages the result as a
+simulated dynamic spectrum with physical time/frequency axes. A ``Simulation``
+instance can be passed directly to the :doc:`Dynspec class <dynspec>` (via the
+``SimDyn`` wrapper) for further analysis.
 
-This is based on original MATLAB code by Coles et al. (2010) "Scattering of pulsar radio emission by the interstellar plasma":
+This is based on the original MATLAB code by Coles et al. (2010),
+`"Scattering of pulsar radio emission by the interstellar plasma"
+<https://ui.adsabs.harvard.edu/abs/2010ApJ...717.1206C>`_.
 
 Simulating a dynamic spectrum from turbulence
 ---------------------------------------------
 
-Input parameters:
+The simulation runs on construction of the object, so a dynamic spectrum can be
+generated with the default parameters in a single line::
 
-    mb2: 
-    dlam:
-    ar:
-    psi:
-    ns:
-    nf:
-    
-    Optional parameters for physical units:
-    freq:
-    dt:
+    from scintools.scint_sim import Simulation
+
+    sim = Simulation()
+
+The resulting object exposes the phase screen, intensity, electric field and
+dynamic spectrum, each of which can be inspected with a dedicated plotting
+method (see `Plotting`_ below).
+
+Input parameters
+----------------
+
+The most commonly adjusted parameters of ``Simulation`` are:
+
+    * **mb2** (`float`) - the maximum Born parameter, which controls the
+      strength of scattering. Default is 2.
+    * **rf** (`float`) - the Fresnel scale, used as the length unit for the
+      simulation. Default is 1.
+    * **ds** (`float`) - the spatial step size in units of ``rf``, used for both
+      the x and y axes unless overridden by ``dx``/``dy``. Default is 0.01.
+    * **alpha** (`float`) - the structure-function exponent. 5/3 (default) is a
+      Kolmogorov spectrum.
+    * **ar** (`float`) - the axial ratio of the anisotropy of the scattering
+      screen. Default is 1 (isotropic).
+    * **psi** (`float`) - the orientation angle of the anisotropy, in degrees,
+      relative to the x axis. Default is 0.
+    * **inner** (`float`) - the inner scale of turbulence, in units of ``rf``.
+      Should generally be smaller than ``ds``. Default is 0.001.
+    * **ns** (`int`) - the size of the simulation in spatial steps, used for
+      both axes unless overridden by ``nx``/``ny``. The total length in
+      refractive scales is ``ns * ds``. Default is 256.
+    * **nf** (`int`) - the number of frequency channels across the fractional
+      bandwidth ``dlam``. Default is 256.
+    * **dlam** (`float`) - the fractional bandwidth relative to the centre
+      frequency. Default is 0.25.
+    * **lamsteps** (`bool`) - if True, take equally-spaced steps in
+      wavelength rather than in frequency. Default is False.
+    * **seed** (`int or None`) - the seed used to generate the random phase
+      screen, for reproducible experiments. Use -1 to reshuffle (draw a
+      fresh, unseeded screen). Default is None (NumPy's global random
+      state).
+
+The number and size of spatial steps can be set independently in x and y,
+overriding ``ns``/``ds``:
+
+    * **nx** (`int or None`) - number of spatial steps in x. Overrides
+      ``ns`` when set. Default is None.
+    * **ny** (`int or None`) - number of spatial steps in y. Overrides
+      ``ns`` when set. Default is None.
+    * **dx** (`float or None`) - spatial step size in x, in units of
+      ``rf``. Overrides ``ds`` when set. Default is None.
+    * **dy** (`float or None`) - spatial step size in y, in units of
+      ``rf``. Overrides ``ds`` when set. Default is None.
+
+The following parameters control what happens at construction time:
+
+    * **plot** (`bool`) - if True, plot the screen, intensity, and dynamic
+      spectrum after the simulation is computed (via ``plot_all``).
+      Default is False.
+    * **verbose** (`bool`) - if True, print progress messages while the
+      simulation runs. Default is False.
+
+Optional parameters for physical units
+---------------------------------------
+
+By default the simulation is dimensionless. The following parameters attach
+physical time and frequency axes to the output dynamic spectrum so that it can
+be handed to the ``Dynspec`` class:
+
+    * **freq** (`float`) - the centre observing frequency, in MHz. Default is
+      1400.
+    * **dt** (`float`) - the subintegration time, in seconds. Default is 30.
+    * **mjd** (`float`) - the MJD of the start of the observation. Default is
+      60000.
+    * **nsub** (`int or None`) - the number of subintegrations to keep in the
+      output dynamic spectrum. If None (default), all ``nx`` steps are kept.
+    * **efield** (`bool`) - if True, store the real part of the electric
+      field instead of the intensity in the output dynamic spectrum.
+      Default is False.
+    * **noise** (`float or None`) - accepted for interface compatibility
+      with other scintools classes; currently unused. Default is None.
+
+A fully specified example
+-------------------------
+
+To simulate a strongly scattered, anisotropic screen with a reproducible seed::
+
+    mb2 = 20    # Born variance, controls the strength of scattering
+    ar = 2      # axial ratio of anisotropy
+    psi = 30    # angle of anisotropy relative to the x axis, in degrees
+    dlam = 0.33 # fractional bandwidth
+    ns = 1024   # size of the simulation in spatial steps
+    nf = 256    # number of frequency channels across dlam
+    seed = 1    # seed for the random phase screen, for reproducibility
+
+    my_sim = Simulation(mb2=mb2, ar=ar, psi=psi, dlam=dlam,
+                        ns=ns, nf=nf, seed=seed)
+
+Plotting
+--------
+
+Each component of the simulation can be visualised directly::
+
+    my_sim.plot_screen()     # the simulated phase screen in x and y
+    my_sim.plot_intensity()  # observer-side intensity fluctuations in space
+    my_sim.plot_dynspec()    # the simulated dynamic spectrum
+    my_sim.plot_efield()     # the real part of the electric field
+    my_sim.plot_delay()      # dispersive group delay and impulse response
+    my_sim.plot_pulse()      # the scatter-broadened pulse in space
+    my_sim.plot_all()        # the screen, intensity and dynamic spectrum
+
+Using a simulation with the Dynspec class
+------------------------------------------
+
+Because the simulated dynamic spectrum carries physical axes, the ``Simulation``
+object can be loaded into a ``Dynspec`` object for the same analysis applied to
+observed data::
+
+    from scintools.dynspec import Dynspec
+
+    dyn = Dynspec(dyn=my_sim)
+    dyn.plot_dyn()

--- a/scintools/dynspec.py
+++ b/scintools/dynspec.py
@@ -4,6 +4,27 @@
 dynspec.py
 ----------------------------------
 Dynamic spectrum class
+
+This module defines the :class:`Dynspec` class, the central object of
+``scintools`` for loading, processing, and analysing pulsar dynamic spectra
+(intensity as a function of time and radio frequency). A :class:`Dynspec`
+object can be created directly from a psrflux-format ASCII file, or wrapped
+around raw arrays / other in-memory formats using one of the lightweight
+helper classes defined at the end of this module:
+
+- :class:`BasicDyn` - wraps a bare 2D flux array plus time/frequency axes.
+- :class:`MatlabDyn` - imports simulated dynamic spectra produced by the
+  Matlab code of Coles et al. (2010).
+- :class:`SimDyn` - imports a :class:`scintools.scint_sim.Simulation` object.
+- :class:`HoloDyn` - imports a model dynamic spectrum produced by the
+  holography code of Walker et al. (2008).
+
+Once loaded, :class:`Dynspec` provides methods for basic processing (e.g.
+trimming, cropping, refilling, and correcting the dynamic spectrum), for
+computing and plotting derived data products (autocorrelation function,
+secondary spectrum, scattered image), and for measuring scintillation
+parameters including arc curvature via ``fit_arc`` and the theta-theta
+technique.
 """
 
 from __future__ import (absolute_import, division,
@@ -39,6 +60,57 @@ import astropy.constants as const
 
 
 class Dynspec:
+    """
+    A pulsar dynamic spectrum: intensity as a function of observing
+    frequency (rows, ``self.freqs``) and time (columns, ``self.times``).
+
+    A ``Dynspec`` is constructed either from a psrflux-format file
+    (``filename=``) or from an in-memory object such as a
+    :class:`BasicDyn`, :class:`MatlabDyn`, :class:`SimDyn`, or
+    :class:`HoloDyn` (``dyn=``); see :meth:`__init__` for details. After
+    loading, the raw dynamic spectrum is available as ``self.dyn`` (a 2D
+    array of shape ``(nchan, nsub)``), with axes ``self.freqs`` (MHz) and
+    ``self.times`` (seconds since the start of the observation).
+
+    Typical usage processes the dynamic spectrum (`trim_edges`, `refill`,
+    `correct_dyn`, `scale_dyn`), then computes and plots derived products
+    such as the autocorrelation function (`calc_acf`/`plot_acf`) and
+    secondary spectrum (`calc_sspec`/`plot_sspec`), and/or fits for the
+    scintillation arc curvature (`fit_arc`) and other scintillation
+    parameters (`get_scint_params`).
+
+    Attributes
+    ----------
+    dyn : ndarray
+        The dynamic spectrum, shape (nchan, nsub).
+    times : ndarray
+        Time axis, seconds since the start of the observation.
+    freqs : ndarray
+        Frequency axis, in MHz.
+    name : str
+        Name of the dynamic spectrum (usually derived from the filename).
+    header : list of str
+        Header lines read from the input file, if any.
+    mjd : float
+        MJD of the start of the observation.
+    nchan : int
+        Number of frequency channels.
+    nsub : int
+        Number of sub-integrations (time steps).
+    freq : float
+        Centre observing frequency, in MHz.
+    bw : float
+        Observation bandwidth, in MHz.
+    df : float
+        Channel bandwidth, in MHz.
+    dt : float
+        Sub-integration duration, in seconds.
+    tobs : float
+        Total observation duration, in seconds.
+    lamsteps : bool
+        Whether the dynamic spectrum has been resampled to equal steps in
+        wavelength rather than frequency.
+    """
 
     def __init__(self, filename=None, dyn=None, verbose=True, process=False,
                  lamsteps=False, remove_short_subs=True, subint_thresh=2.33,
@@ -1890,6 +1962,25 @@ class Dynspec:
                 np.exp(1j*np.angle(self.wavefield[posdspec]))
 
     def calc_asymmetry(self, verbose=False, pool=None):
+        """
+        Compute the theta-theta asymmetry parameter for each fitting chunk,
+        which quantifies the left-right (forward-backward) asymmetry of the
+        scintillation arc power and can indicate the presence of anisotropic
+        or bimodal scattering.
+
+        Runs `fit_thetatheta` first if it has not already been called.
+        Populates `self.asymmetry`, a complex array of shape
+        (`self.ncf_fit`, `self.nct_fit`).
+
+        Parameters
+        ----------
+        verbose : bool, optional
+            Option to print progress information. Defaults to False
+        pool : ThreadPool, optional
+            Pool of workers for parallel processing. Currently supports Pool
+            from multiprocessing and MPIPool from mpipool. Defaults
+            to None and runs chunks in series.
+        """
         if not hasattr(self, "ththeta"):
             self.fit_thetatheta(verbose=verbose, pool=pool)
         self.asymmetry = np.zeros((self.ncf_fit, self.nct_fit), dtype=complex)
@@ -4144,6 +4235,18 @@ class Dynspec:
 
 
 class BasicDyn():
+    """
+    Lightweight container for a dynamic spectrum built directly from arrays.
+
+    Wraps a 2D flux array together with its time/frequency axes and
+    observation metadata so that it can be passed to the `Dynspec` class,
+    which reads these attributes on construction::
+
+        basic = BasicDyn(dyn, times=times, freqs=freqs)
+        dynspec = Dynspec(dyn=basic)
+
+    See `BasicDyn.__init__` for the full list of accepted parameters.
+    """
 
     def __init__(self, dyn, name="BasicDyn", header=["BasicDyn"], times=[],
                  freqs=[], nchan=None, nsub=None, bw=None, df=None,
@@ -4211,6 +4314,13 @@ class BasicDyn():
 
 
 class MatlabDyn():
+    """
+    Loader for simulated dynamic spectra stored in MATLAB ``.mat`` files.
+
+    Reads a dynamic spectrum produced by the original MATLAB simulation
+    code of Coles et al. (2010) and exposes it with the attributes expected
+    by the `Dynspec` class. See `MatlabDyn.__init__` for details.
+    """
 
     def __init__(self, matfilename):
         """
@@ -4262,6 +4372,14 @@ class MatlabDyn():
 
 
 class SimDyn():
+    """
+    Adapter that exposes a `scint_sim.Simulation` object to the `Dynspec`
+    class.
+
+    Copies the simulated dynamic spectrum and its derived time/frequency
+    axes and metadata into the attribute layout expected by `Dynspec`. See
+    `SimDyn.__init__` for details.
+    """
 
     def __init__(self, sim):
         """
@@ -4302,6 +4420,15 @@ class SimDyn():
 
 
 class HoloDyn():
+    """
+    Loader for model dynamic spectra from the holography code of Walker et
+    al. (2008).
+
+    Reads the real (and optional imaginary) components of a model dynamic
+    spectrum from FITS files, combines them into a complex field, and
+    exposes the amplitude with the attributes expected by the `Dynspec`
+    class. See `HoloDyn.__init__` for details.
+    """
 
     def __init__(self, holofile, imholofile=None, df=1, dt=1, fmin=0, mjd=0):
         """

--- a/scintools/dynspec.py
+++ b/scintools/dynspec.py
@@ -569,13 +569,11 @@ class Dynspec:
                 dyn = self.dyn
         else:
             dyn = input_dyn
-        medval = np.median(dyn[is_valid(dyn)*np.array(np.abs(
-                                                      is_valid(dyn)) > 0)])
-        minval = np.min(dyn[is_valid(dyn)*np.array(np.abs(
-                                                   is_valid(dyn)) > 0)])
+        finite_nonzero = is_valid(dyn) * (np.abs(dyn) > 0)
+        medval = np.median(dyn[finite_nonzero])
+        minval = np.min(dyn[finite_nonzero])
         # standard deviation
-        std = np.std(dyn[is_valid(dyn)*np.array(np.abs(
-                                                is_valid(dyn)) > 0)])
+        std = np.std(dyn[finite_nonzero])
         vmin = minval + std
         vmax = medval + 4*std
 
@@ -1216,6 +1214,7 @@ class Dynspec:
                 etamax = etamax*beta_to_eta
                 etamin = etamin/(self.freq/ref_freq)**2
                 etamin = etamin*beta_to_eta
+                constraint = np.array(constraint, dtype=float)
                 constraint = constraint/(self.freq/ref_freq)**2
                 constraint = constraint*beta_to_eta
 
@@ -2205,7 +2204,7 @@ class Dynspec:
 
         if logsteps:
             masklin += np.isnan(normSspeclin)
-            normSspeclin = np.ma.array(normSspeclin, mask=mask)
+            normSspeclin = np.ma.array(normSspeclin, mask=masklin)
             mask += np.isnan(normSspec)
             normSspec = np.ma.array(normSspec, mask=mask)
             self.mask = mask
@@ -2854,8 +2853,8 @@ class Dynspec:
                 if ndnu > (self.bw / dnu):
                     if verbose:
                         print('WARNING: nscale exceeds range in frequency lag')
-                    tmin = 0
-                    tmax = nf
+                    fmin = 0
+                    fmax = nf
                 else:
                     fframe = int(round(ndnu * (dnu / self.df)))
                     fmin = int(np.floor(
@@ -3745,7 +3744,7 @@ class Dynspec:
                     self.scale_dyn(scale='velocity')
                 dyn = cp(self.vdyn)
             elif trap:
-                if not hasattr(self, 'trap'):
+                if not hasattr(self, 'trapdyn'):
                     self.scale_dyn(scale='trapezoid')
                 dyn = cp(self.trapdyn)
             else:
@@ -4070,8 +4069,8 @@ class Dynspec:
                 arin2 = cp(self.lamdyn)  # input array
                 nf2, nt2 = np.shape(arin2)
                 arout2 = np.zeros([nf2, nt2])
-            mjd = np.asarray(self.mjd, dtype=np.float128) + \
-                np.asarray(self.times, dtype=np.float128)/86400
+            mjd = np.asarray(self.mjd, dtype=np.longdouble) + \
+                np.asarray(self.times, dtype=np.longdouble)/86400
 
             print('Getting SSB delays')
             ssb_delays = get_ssb_delay(mjd, pars['RAJ'], pars['DECJ'])
@@ -4248,8 +4247,8 @@ class BasicDyn():
     See `BasicDyn.__init__` for the full list of accepted parameters.
     """
 
-    def __init__(self, dyn, name="BasicDyn", header=["BasicDyn"], times=[],
-                 freqs=[], nchan=None, nsub=None, bw=None, df=None,
+    def __init__(self, dyn, name="BasicDyn", header=None, times=None,
+                 freqs=None, nchan=None, nsub=None, bw=None, df=None,
                  freq=None, tobs=None, dt=None, mjd=60000):
         """
         Define a basic dynamic spectrum object from an array of fluxes
@@ -4295,10 +4294,13 @@ class BasicDyn():
         """
 
         # Set parameters from input
-        if times.size == 0 or freqs.size == 0:
+        if times is None or freqs is None or len(times) == 0 \
+                or len(freqs) == 0:
             raise ValueError('must input array of times and frequencies')
+        times = np.asarray(times)
+        freqs = np.asarray(freqs)
         self.name = name
-        self.header = header
+        self.header = header if header is not None else ["BasicDyn"]
         self.times = times  # times should be the start times of each bin
         self.freqs = freqs
         self.nchan = nchan if nchan is not None else len(freqs)
@@ -4307,7 +4309,7 @@ class BasicDyn():
         self.df = df if df is not None else np.mean(np.abs(np.diff(freqs)))
         self.freq = freq if freq is not None else np.mean(np.unique(freqs))
         self.dt = dt if dt is not None else np.mean(np.abs(np.diff(times)))
-        self.tobs = tobs if tobs is not None else np.ptp(times) + dt
+        self.tobs = tobs if tobs is not None else np.ptp(times) + self.dt
         self.mjd = mjd
         self.dyn = dyn
         return
@@ -4342,13 +4344,13 @@ class MatlabDyn():
         self.matfile = loadmat(matfilename)  # reads matfile to a dictionary
         try:
             self.dyn = self.matfile['spi']
-        except NameError:
-            raise NameError('No variable named "spi" found in mat file')
+        except KeyError:
+            raise KeyError('No variable named "spi" found in mat file')
 
         try:
             dlam = float(self.matfile['dlam'])
-        except NameError:
-            raise NameError('No variable named "dlam" found in mat file')
+        except KeyError:
+            raise KeyError('No variable named "dlam" found in mat file')
         # Set parameters from input
         self.name = matfilename.split()[0]
         self.header = [self.matfile['__header__'], ["Dynspec loaded \
@@ -4398,7 +4400,7 @@ class SimDyn():
         if sim.lamsteps:
             self.name += ',lamsteps'
 
-        self.header = self.header
+        self.header = [self.name]
         self.dyn = sim.spi
         dlam = sim.dlam
 

--- a/scintools/dynspec.py
+++ b/scintools/dynspec.py
@@ -337,6 +337,10 @@ class Dynspec:
         bandwagon_frac : float in [0,1], optional
             Set entire edge to zero if more than this fraction of the edge
             pixels is zero or NaN. The default is 0.5.
+        remove_short_sub : bool, optional
+            Currently unused and reserved for future use; short
+            sub-integrations are removed at load time by
+            `remove_short_subs`, not here. The default is True.
 
         """
 
@@ -971,7 +975,7 @@ class Dynspec:
 
         """
 
-        c = 299792458.0  # m/s
+        c = sc.c  # m/s (speed of light)
         if input_scattered_image is None:
             if not hasattr(self, 'scattered_image'):
                 self.calc_scattered_image(lamsteps=lamsteps, trap=trap,
@@ -1208,7 +1212,7 @@ class Dynspec:
                 etamax = etamax_array.squeeze()[iarc]
 
             if not lamsteps:
-                c = 299792458.0  # m/s
+                c = sc.c  # m/s (speed of light)
                 beta_to_eta = c*1e6/((ref_freq*10**6)**2)
                 etamax = etamax/(self.freq/ref_freq)**2  # correct for freq
                 etamax = etamax*beta_to_eta
@@ -2120,7 +2124,7 @@ class Dynspec:
                 eta = self.eta
         else:  # convert to beta
             if not lamsteps:
-                c = 299792458.0  # m/s
+                c = sc.c  # m/s (speed of light)
                 beta_to_eta = c*1e6/((ref_freq*10**6)**2)
                 eta = eta/(self.freq/ref_freq)**2  # correct for frequency
                 eta = eta*beta_to_eta
@@ -2999,39 +3003,8 @@ class Dynspec:
                         results = res
 
         elif method == 'sspec':
-            '''
-            sspec method
-            '''
+            # The secondary-spectrum fitting method is not yet implemented.
             print("This method doesn't work yet, do something else")
-            # fdyn = np.fft.fft2(self.dyn, (2 * nf, 2 * nt))
-            # fdynsq = fdyn * np.conjugate(fdyn)
-
-            # secspec = np.real(fdynsq)
-            # secspec = np.fft.fftshift(fdynsq)
-            # secspec = secspec[nf:2*nf, :]
-            # secspec = np.real(secspec)
-
-            # rowsum = np.sum(secspec[:, :nt], axis=0)
-            # ydata_t = rowsum / (2*nf)
-            # colsum = np.sum(secspec[:nf, :], axis=1)
-            # ydata_f = colsum / (2 * nt)
-
-            # # concatenate x and y arrays
-            # xdata = np.array(np.concatenate((xdata_t, xdata_f)))
-            # ydata = np.concatenate((ydata_t, ydata_f))
-
-            # if verbose:
-            #     print("\nPerforming least-squares fit to secondary spectrum")
-            # chisqr = np.inf
-            # for itr in range(nitr):
-            #     results = fitter(scint_sspec_model, params,
-            #                      (xdata, ydata), nan_policy=nan_policy,
-            #                       mcmc=mcmc, is_weighted=(not lnsigma),
-            #                       burn=burn, nwalkers=nwalkers, steps=steps)
-            #     if results.chisqr < chisqr:
-            #         chisqr = results.chisqr
-            #         params = results.params
-            #         res = results
 
         if results.params['tau'].stderr is None or \
            results.params['dnu'].stderr is None:
@@ -3587,7 +3560,7 @@ class Dynspec:
                 self.fit_arc(lamsteps=lamsteps,
                              log_parabola=True, plot=plot_fit)
             if lamsteps:
-                c = 299792458.0  # m/s
+                c = sc.c  # m/s (speed of light)
                 beta_to_eta = c * 1e6 / ((ref_freq * 1e6)**2)
                 # correct for freq
                 eta = self.betaeta / (self.freq / ref_freq)**2
@@ -4175,24 +4148,8 @@ class Dynspec:
             nt = np.shape(dyn)[1]
             if window is not None:
                 # Window the dynamic spectrum
-                if window == 'hanning':
-                    cw = np.hanning(np.floor(window_frac*nt))
-                    sw = np.hanning(np.floor(window_frac*nf))
-                elif window == 'hamming':
-                    cw = np.hamming(np.floor(window_frac*nt))
-                    sw = np.hamming(np.floor(window_frac*nf))
-                elif window == 'blackman':
-                    cw = np.blackman(np.floor(window_frac*nt))
-                    sw = np.blackman(np.floor(window_frac*nf))
-                elif window == 'bartlett':
-                    cw = np.bartlett(np.floor(window_frac*nt))
-                    sw = np.bartlett(np.floor(window_frac*nf))
-                else:
-                    print('Window unknown.. Please add it!')
-                chan_window = np.insert(cw, int(np.ceil(len(cw)/2)),
-                                        np.ones([nt-len(cw)]))
-                subint_window = np.insert(sw, int(np.ceil(len(sw)/2)),
-                                          np.ones([nf-len(sw)]))
+                chan_window, subint_window = get_window(nt, nf, window=window,
+                                                        frac=window_frac)
                 dyn = np.multiply(chan_window, dyn)
                 dyn = np.transpose(np.multiply(subint_window,
                                                np.transpose(dyn)))

--- a/scintools/scint_models.py
+++ b/scintools/scint_models.py
@@ -1,22 +1,40 @@
 #!/usr/bin/env python
 
 """
-models.py
+scint_models.py
 ----------------------------------
-Scintillation models
+Scintillation models.
 
-A library of scintillation models to use with lmfit, emcee, or bilby
+A library of scintillation models to use with ``lmfit``, ``emcee``, or
+``bilby`` for modelling and fitting pulsar scintillation data. This
+includes:
 
-    Each model has at least inputs:
+* 1D and 2D autocorrelation function (ACF) models for measuring the
+  scintillation timescale and decorrelation bandwidth.
+* Secondary spectrum models, including power-law noise spectra and
+  scintillation arc power/curvature.
+* Effective velocity models (annual and orbital terms, and the "thin
+  screen" relation between arc curvature and effective velocity) used
+  to infer pulsar distances, orbital inclinations, and other binary
+  parameters from scintillation arcs.
+
+Most fitting-model functions share a common calling convention:
+
+    Inputs (at least):
         params
         xdata
         ydata
         weights
 
-    And output:
+    Output:
         residuals = (ydata - model) * weights
 
-    Some functions use additional inputs
+Some functions use additional inputs, and a few (documented below,
+e.g. ``effective_velocity_annual``, ``arc_weak``, ``arc_weak_2d``) do
+not return residuals for a fitter but instead return the model values
+directly. The :func:`fitter` function is the common entry point used
+to drive these models with ``lmfit``'s ``Minimizer`` (least-squares or
+``emcee``/MCMC).
 """
 
 from __future__ import (absolute_import, division,
@@ -29,6 +47,75 @@ from lmfit import Minimizer
 def fitter(model, params, args, mcmc=False, pos=None, nwalkers=100,
            steps=1000, burn=0.2, progress=True, workers=1,
            nan_policy='raise', max_nfev=None, thin=10, is_weighted=True):
+    """
+    Common entry point for fitting one of the residual-returning
+    models in this module using ``lmfit``.
+
+    Wraps the model function and starting parameters in an ``lmfit``
+    ``Minimizer`` and either performs a least-squares minimisation, or
+    (if ``mcmc=True``) runs the ``emcee`` MCMC sampler via
+    ``Minimizer.emcee``.
+
+    Parameters
+    ----------
+    model : callable
+        A model function from this module (e.g. `tau_acf_model`,
+        `scint_acf_model`, `scint_acf_model_2d_approx`,
+        `powerspectrum_model`) that takes ``params`` followed by the
+        contents of `args` and returns the (weighted) residuals
+        between data and model.
+    params : lmfit.Parameters
+        Initial/starting parameters for the fit.
+    args : tuple
+        Extra positional arguments passed to `model` after `params`
+        (typically some combination of ``xdata``, ``ydata``, and
+        ``weights``).
+    mcmc : bool, optional
+        If True, sample the posterior with ``emcee`` instead of doing
+        a least-squares fit. Default is False.
+    pos : array_like, optional
+        Initial walker positions passed to ``Minimizer.emcee`` (only
+        used if `mcmc` is True). Default is None (let ``emcee``
+        initialise the walkers).
+    nwalkers : int, optional
+        Number of ``emcee`` walkers (only used if `mcmc` is True).
+        Default is 100.
+    steps : int, optional
+        Number of ``emcee`` steps to run (only used if `mcmc` is
+        True). Default is 1000.
+    burn : float, optional
+        Fraction of `steps` to discard as burn-in (only used if `mcmc`
+        is True); converted internally to an integer number of steps
+        via ``int(burn * steps)``. Default is 0.2.
+    progress : bool, optional
+        Whether ``emcee`` prints a progress bar (only used if `mcmc`
+        is True). Default is True.
+    workers : int, optional
+        Number of parallel workers for ``emcee`` (only used if `mcmc`
+        is True). Default is 1.
+    nan_policy : str, optional
+        How ``lmfit`` should handle NaNs in the residuals for the
+        least-squares fit (only used if `mcmc` is False). Default is
+        'raise'.
+    max_nfev : int, optional
+        Maximum number of function evaluations for the least-squares
+        fit (only used if `mcmc` is False). Default is None (use the
+        ``lmfit`` default).
+    thin : int, optional
+        Only accept every `thin`-th ``emcee`` sample (only used if
+        `mcmc` is True). Default is 10.
+    is_weighted : bool, optional
+        Whether the residuals returned by `model` are already
+        weighted, passed through to ``Minimizer.emcee`` (only used if
+        `mcmc` is True). Default is True.
+
+    Returns
+    -------
+    results : lmfit.minimizer.MinimizerResult
+        The fit result object returned by ``Minimizer.minimize()``
+        (least-squares) or ``Minimizer.emcee()`` (MCMC), containing
+        the best-fit (or posterior) parameters and fit statistics.
+    """
 
     # Do fit
     if mcmc:
@@ -47,6 +134,31 @@ def fitter(model, params, args, mcmc=False, pos=None, nwalkers=100,
 
 
 def powerspectrum_model(params, xdata, ydata):
+    """
+    Model a red-noise power spectrum (e.g. of the frequency-averaged
+    secondary spectrum / cross-power vs sqrt(delay)) as a power law
+    plus a white-noise floor, and return the residuals.
+
+    model = wn + amp * xdata**alpha
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the white-noise
+        level ('wn'), power-law amplitude ('amp'), and power-law index
+        ('alpha').
+    xdata : numpy.ndarray
+        Independent variable (e.g. sqrt of delay/tdel).
+    ydata : numpy.ndarray
+        Power spectrum values corresponding to `xdata`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Residual of model and data (``ydata - model``). Unlike most
+        other model functions in this module, this residual is not
+        multiplied by weights.
+    """
 
     parvals = params.valuesdict()
 
@@ -61,11 +173,30 @@ def powerspectrum_model(params, xdata, ydata):
 
 def tau_acf_model(params, xdata, ydata, weights):
     """
-    Fit 1D function to cut through ACF for scintillation timescale.
-    Exponent is 5/3 for Kolmogorov turbulence.
-        amp = Amplitude
-        tau = timescale at 1/e
-        alpha = index of exponential function. 2 is Gaussian, 5/3 is Kolmogorov
+    Model a 1D cut through the center of the ACF along the time axis
+    and return the residuals.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit amplitude ('amp'), timescale at 1/e width ('tau'),
+        and index of the exponential function ('alpha'; 2 is
+        Gaussian, 5/3 is Kolmogorov).
+    xdata : numpy.ndarray
+        Time of sub-integrations from the center of the ACF to the
+        maximum time.
+    ydata : numpy.ndarray
+        ACF pixel values corresponding to `xdata` and running through
+        the center of the ACF.
+    weights : numpy.ndarray or None
+        Weights of the data. If None, uniform weights of ones are
+        used, with the white-noise spike (first element) excluded.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted residual of model and data.
     """
 
     if weights is None:
@@ -87,10 +218,32 @@ def tau_acf_model(params, xdata, ydata, weights):
 
 def dnu_acf_model(params, xdata, ydata, weights):
     """
-    Fit 1D function to cut through ACF for decorrelation bandwidth.
-    Default function has is exponential with dnu measured at half power
-        amp = Amplitude
-        dnu = bandwidth at 1/2 power
+    Model a 1D cut through the center of the ACF along the frequency
+    axis and return the residuals.
+
+    Default function is exponential with `dnu` measured at half
+    power.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit amplitude ('amp') and decorrelation bandwidth at
+        half power ('dnu').
+    xdata : numpy.ndarray
+        Frequency of the channels from the center of the ACF to the
+        maximum frequency.
+    ydata : numpy.ndarray
+        ACF pixel values corresponding to `xdata` and running through
+        the center of the ACF.
+    weights : numpy.ndarray or None
+        Weights of the data. If None, uniform weights of ones are
+        used, with the white-noise spike (first element) excluded.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted residual of model and data.
     """
 
     if weights is None:
@@ -111,7 +264,33 @@ def dnu_acf_model(params, xdata, ydata, weights):
 
 def scint_acf_model(params, xdata, ydata, weights):
     """
-    Fit both tau (tau_acf_model) and dnu (dnu_acf_model) simultaneously
+    Apply `tau_acf_model` and `dnu_acf_model` simultaneously and
+    return the concatenated residuals.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit amplitude ('amp'), timescale at 1/e width ('tau'),
+        decorrelation bandwidth at half power ('dnu'), and index of
+        the exponential function ('alpha').
+    xdata : tuple of numpy.ndarray
+        Two-element sequence ``(xdata_t, xdata_f)`` with the time and
+        frequency axes, passed through to `tau_acf_model` and
+        `dnu_acf_model` respectively.
+    ydata : tuple of numpy.ndarray
+        Two-element sequence ``(ydata_t, ydata_f)`` with the ACF cuts
+        along time and frequency, passed through to `tau_acf_model`
+        and `dnu_acf_model` respectively.
+    weights : tuple of numpy.ndarray
+        Two-element sequence ``(weights_t, weights_f)`` with the
+        weights for the time and frequency cuts respectively.
+
+    Returns
+    -------
+    numpy.ndarray
+        Concatenation of the weighted residuals from `tau_acf_model`
+        and `dnu_acf_model`.
     """
 
     residuals_t = tau_acf_model(params, xdata[0], ydata[0], weights[0])
@@ -122,7 +301,36 @@ def scint_acf_model(params, xdata, ydata, weights):
 
 def scint_acf_model_2d_approx(params, tdata, fdata, ydata, weights):
     """
-    Fit an approximate 2D ACF function
+    Model an approximate 2D ACF that incorporates a phase gradient,
+    and return the residuals.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit amplitude ('amp'), timescale at 1/e width ('tau'),
+        decorrelation bandwidth at half power ('dnu'), index of the
+        exponential function ('alpha'), and phase gradient
+        ('phasegrad'), as well as the total observation time
+        ('tobs') and total bandwidth ('bw').
+    tdata : numpy.ndarray
+        Times of sub-integrations along the desired range, centered
+        on the sub-integration next to that of the white-noise spike.
+    fdata : numpy.ndarray
+        Frequencies of channels along the desired range, centered on
+        the channel next to that of the white-noise spike.
+    ydata : numpy.ndarray
+        ACF cropped to the range of times and frequencies matching
+        `tdata` and `fdata`.
+    weights : numpy.ndarray or None
+        Weights of the data, in FFT (fftshift) ordering. If None,
+        uniform weights of ones are used. The white-noise spike is
+        excluded from the fit.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted residual of model and data.
     """
 
     parvals = params.valuesdict()
@@ -163,7 +371,37 @@ def scint_acf_model_2d_approx(params, tdata, fdata, ydata, weights):
 
 def scint_acf_model_2d(params, ydata, weights):
     """
-    Fit an analytical 2D ACF function
+    Model an analytical 2D ACF using the `scintools.scint_sim.ACF`
+    class, and return the residuals.
+
+    This method is significantly slower than
+    `scint_acf_model_2d_approx`.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit timescale at 1/e width ('tau'), decorrelation
+        bandwidth at half power ('dnu'), index of the exponential
+        function ('alpha'), axial ratio of anisotropy ('ar'),
+        orientation of anisotropy ('psi'), phase gradient
+        ('phasegrad'), rotation of the phase gradient ('theta'), and
+        amplitude ('amp'), as well as the total observation time
+        ('tobs'), total bandwidth ('bw'), and number of
+        sub-integrations and channels used to build the model ACF
+        ('nt', 'nf').
+    ydata : numpy.ndarray
+        2D ACF cropped symmetrically around its center to a desired
+        range, with shape ``(nf_crop, nt_crop)``.
+    weights : numpy.ndarray or None
+        Weights of the data, in FFT (fftshift) ordering. If None,
+        uniform weights of ones are used. The white-noise spike is
+        excluded from the fit.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted residual of model and data.
     """
 
     parvals = params.valuesdict()
@@ -217,11 +455,28 @@ def scint_acf_model_2d(params, ydata, weights):
 
 def tau_sspec_model(params, xdata, ydata):
     """
-    Fit 1D function to cut through ACF for scintillation timescale.
-    Exponent is 5/3 for Kolmogorov turbulence.
-        amp = Amplitude
-        tau = timescale at 1/e
-        alpha = index of exponential function. 2 is Gaussian, 5/3 is Kolmogorov
+    Model a 1D cut through the center of the ACF along the time axis
+    and apply a Fourier transform, returning the residuals against
+    the secondary-spectrum profile.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters or dict-like
+        Object containing the current best-fit amplitude ('amp'),
+        timescale at 1/e width ('tau'), and index of the exponential
+        function ('alpha'; 2 is Gaussian, 5/3 is Kolmogorov).
+    xdata : numpy.ndarray
+        Time of sub-integrations from the center of the ACF to the
+        maximum time.
+    ydata : numpy.ndarray
+        Profile from the secondary spectrum corresponding to the ACF
+        to model, summed along all columns (all f_t).
+
+    Returns
+    -------
+    numpy.ndarray
+        Residual of model and data, weighted by the model itself
+        (used as an approximation of the noise).
     """
 
     amp = params['amp']
@@ -247,10 +502,30 @@ def tau_sspec_model(params, xdata, ydata):
 
 def dnu_sspec_model(params, xdata, ydata):
     """
-    Fit 1D function to cut through ACF for decorrelation bandwidth.
-    Default function has is exponential with dnu measured at half power
-        amp = Amplitude
-        dnu = bandwidth at 1/2 power
+    Model a 1D cut through the center of the ACF along the frequency
+    axis and apply a Fourier transform, returning the residuals
+    against the secondary-spectrum profile.
+
+    Default function is exponential with `dnu` measured at half
+    power.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters or dict-like
+        Object containing the current best-fit amplitude ('amp') and
+        decorrelation bandwidth at half power ('dnu').
+    xdata : numpy.ndarray
+        Frequency of the channels from the center of the ACF to the
+        maximum frequency.
+    ydata : numpy.ndarray
+        Profile from the secondary spectrum corresponding to the ACF
+        to model, summed along all rows (all f_tau or f_lambda).
+
+    Returns
+    -------
+    numpy.ndarray
+        Residual of model and data, weighted by the model itself
+        (used as an approximation of the noise).
     """
 
     amp = params['amp']
@@ -275,7 +550,43 @@ def dnu_sspec_model(params, xdata, ydata):
 
 def scint_sspec_model(params, xdata, ydata, weights):
     """
-    Fit both tau (tau_sspec_model) and dnu (dnu_sspec_model) simultaneously
+    Apply `tau_sspec_model` and `dnu_sspec_model` simultaneously and
+    return the concatenated residuals.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters or dict-like
+        Object containing the current best-fit amplitude ('amp'),
+        timescale at 1/e width ('tau'), decorrelation bandwidth at
+        half power ('dnu'), and index of the exponential function
+        ('alpha').
+    xdata : tuple of numpy.ndarray
+        Two-element sequence ``(xdata_t, xdata_f)`` with the time and
+        frequency axes, passed through to `tau_sspec_model` and
+        `dnu_sspec_model` respectively.
+    ydata : tuple of numpy.ndarray
+        Two-element sequence ``(ydata_t, ydata_f)`` with the
+        secondary-spectrum profiles along time and frequency, passed
+        through to `tau_sspec_model` and `dnu_sspec_model`
+        respectively.
+    weights : sequence
+        Two-element sequence ``(weights_t, weights_f)``, passed as an
+        extra positional argument to `tau_sspec_model` and
+        `dnu_sspec_model`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Concatenation of the residuals from `tau_sspec_model` and
+        `dnu_sspec_model`.
+
+    Raises
+    ------
+    TypeError
+        `tau_sspec_model` and `dnu_sspec_model` only accept
+        ``(params, xdata, ydata)``, so calling them here with an
+        extra `weights` element currently raises a TypeError. This
+        function is not presently called elsewhere in the package.
     """
 
     residuals_t = tau_sspec_model(params, xdata[0], ydata[0], weights[0])
@@ -286,8 +597,33 @@ def scint_sspec_model(params, xdata, ydata, weights):
 
 def arc_power_curve(params, xdata, ydata, weights):
     """
-    Returns a template for the power curve in secondary spectrum vs
-    sqrt(curvature) or normalised fdop
+    Return a template for the power curve in the secondary spectrum
+    against sqrt(curvature) or normalised f_t.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object (currently unused by the
+        model itself).
+    xdata : numpy.ndarray
+        Square-root arc curvatures.
+    ydata : numpy.ndarray
+        Secondary-spectrum power profile.
+    weights : numpy.ndarray or None
+        Weights of the data. If None, uniform weights of ones are
+        used.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted residual of model and data.
+
+    Notes
+    -----
+    The model template is not yet implemented: `model` is currently
+    an empty list, so ``ydata - model`` will raise a
+    ``ValueError`` (mismatched shapes) for any non-empty `ydata`.
+    This function is not presently called elsewhere in the package.
     """
 
     if weights is None:
@@ -299,7 +635,24 @@ def arc_power_curve(params, xdata, ydata, weights):
 
 def fit_parabola(x, y):
     """
-    Fit a parabola and return the value and error for the peak
+    Fit a parabola and return the value and error for the peak.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        x values of the peak profile.
+    y : numpy.ndarray
+        y values of the peak profile.
+
+    Returns
+    -------
+    yfit : numpy.ndarray
+        y values of the fit, evaluated at `x`.
+    peak : float
+        Fit peak value (x position of the parabola's turning point).
+    peak_error : float
+        Uncertainty on `peak`, propagated from the covariance of the
+        fitted parabola coefficients.
     """
 
     # increase range to help fitter
@@ -328,7 +681,28 @@ def fit_parabola(x, y):
 
 def fit_log_parabola(x, y):
     """
-    Fit a log-parabola and return the value and error for the peak
+    Fit a log-parabola and return the value and error for the peak.
+
+    Takes the natural log of `x`, fits a parabola in log-x space via
+    `fit_parabola`, and converts the resulting peak position and
+    error back to linear `x` units.
+
+    Parameters
+    ----------
+    x : numpy.ndarray
+        x values of the peak profile (must be positive, since the
+        log is taken).
+    y : numpy.ndarray
+        y values of the peak profile.
+
+    Returns
+    -------
+    yfit : numpy.ndarray
+        y values of the fit, evaluated at (rescaled) log(`x`).
+    peak : float
+        Fit peak value, in linear `x` units.
+    peak_error : float
+        Uncertainty on `peak`, in linear `x` units.
     """
 
     # Take the log of x
@@ -351,9 +725,63 @@ def arc_curvature(params, ydata, weights, true_anomaly,
                   vearth_ra, vearth_dec, mjd=None, model_only=False,
                   return_veff=False):
     """
-    arc curvature model
+    Model the arc curvature and return the residuals (or, optionally,
+    the model curvature and effective velocity components directly).
 
-        ydata: arc curvature
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit distance to the pulsar in kpc ('d') and fractional
+        screen distance ('s'), plus the parameters required by
+        `effective_velocity_annual`. Optionally also: an anisotropy
+        model flag ('nmodel'), anisotropy angle ('zeta', required if
+        anisotropic), ISM velocity in RA/Dec ('vism_ra', 'vism_dec')
+        or, for the anisotropic case, ISM velocity along `zeta`
+        ('vism_zeta'). The deprecated parameter names 'psi' and
+        'vism_psi' are no longer supported (use 'zeta' and
+        'vism_zeta' instead).
+    ydata : numpy.ndarray
+        Arc curvature data.
+    weights : numpy.ndarray or None
+        Weights of the data. If None (and `model_only` is False),
+        uniform weights of ones are used.
+    true_anomaly : numpy.ndarray
+        True anomalies corresponding to the data.
+    vearth_ra : numpy.ndarray
+        Earth velocity in RA corresponding to the data.
+    vearth_dec : numpy.ndarray
+        Earth velocity in Dec corresponding to the data.
+    mjd : numpy.ndarray or float, optional
+        MJDs corresponding to the data, used for the 'OMDOT'
+        correction in `effective_velocity_annual`. Default is None.
+    model_only : bool, optional
+        If True, return the model curvature (and, if `return_veff` is
+        also True, the effective velocity components) instead of the
+        residuals. Default is False.
+    return_veff : bool, optional
+        If True (and `model_only` is also True), also return the
+        ISM-subtracted effective velocity components in RA and Dec.
+        Default is False.
+
+    Returns
+    -------
+    numpy.ndarray
+        If `model_only` is False: the weighted residual of model and
+        data, ``(ydata - model) * weights``.
+    model : numpy.ndarray
+        If `model_only` is True: the model arc curvature, in units of
+        1/(m mHz**2).
+    veff_ra, veff_dec : numpy.ndarray
+        If `model_only` and `return_veff` are both True: the
+        ISM-subtracted effective velocity in RA and Dec, returned in
+        addition to `model`.
+
+    Raises
+    ------
+    KeyError
+        If the deprecated parameter 'psi' or 'vism_psi' is present in
+        `params`.
     """
 
     # ensure dimensionality of arrays makes sense
@@ -428,10 +856,43 @@ def arc_curvature(params, ydata, weights, true_anomaly,
 def veff_thin_screen(params, ydata, weights, true_anomaly,
                      vearth_ra, vearth_dec, mjd=None):
     """
-    Effective velocity thin screen model.
-    Uses Eq. 4 from Rickett et al. (2014) for anisotropy coefficients.
+    Model the effective velocity implied by a thin-screen scattering
+    geometry and return the residuals.
 
-        ydata: arc curvature
+    Uses Eq. 4 from Rickett et al. (2014) for the anisotropy
+    coefficients.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing the current
+        best-fit fractional screen distance ('s') and pulsar distance
+        in kpc ('d'), plus the parameters required by
+        `effective_velocity_annual`. Optionally also: a scaling
+        factor ('kappa', default 1), an anisotropy model flag
+        ('nmodel'), and for the anisotropic case an axial ratio
+        parameter ('R') and anisotropy angle in degrees ('psi'). ISM
+        velocity in RA/Dec ('vism_ra', 'vism_dec') may also be given
+        and is subtracted from the effective velocity.
+    ydata : numpy.ndarray
+        Measured effective velocity (or, equivalently, quantity
+        proportional to it via the arc curvature) data.
+    weights : numpy.ndarray
+        Weights of the data.
+    true_anomaly : numpy.ndarray
+        True anomalies corresponding to the data.
+    vearth_ra : numpy.ndarray
+        Earth velocity in RA corresponding to the data.
+    vearth_dec : numpy.ndarray
+        Earth velocity in Dec corresponding to the data.
+    mjd : numpy.ndarray or float, optional
+        MJDs corresponding to the data, used for the 'OMDOT'
+        correction in `effective_velocity_annual`. Default is None.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighted residual of model and data.
     """
 
     # ensure dimensionality of arrays makes sense
@@ -504,8 +965,56 @@ Below: Models that do not return residuals for a fitter
 def effective_velocity_annual(params, true_anomaly, vearth_ra, vearth_dec,
                               mjd=None):
     """
-    Effective velocity with annual and pulsar terms
-        Note: Does NOT include IISM velocity, but returns veff in IISM frame
+    Compute the effective velocity including annual (Earth orbital
+    and proper motion) and pulsar orbital terms.
+
+    Note: this does NOT include the interstellar medium (IISM)
+    velocity, but the returned effective velocity is expressed in the
+    IISM frame.
+
+    Parameters
+    ----------
+    params : lmfit.Parameters
+        ``lmfit`` ``Parameters()`` object containing, if the pulsar is
+        in a binary: the projected semi-major axis in lt-s ('A1'),
+        orbital period in days ('PB'), orbital eccentricity ('ECC'),
+        longitude of periastron in degrees ('OM'), inclination via
+        one of 'KIN' (degrees), 'COSI', or 'SINI', and optionally an
+        inclination-sense flag ('sense') and periastron-advance rate
+        in deg/yr ('OMDOT', requires 'T0' and `mjd`). Also,
+        optionally, the proper motion in RA and Dec ('PMRA', 'PMDEC',
+        mas/yr), and always the longitude of the ascending node in
+        degrees ('KOM'), the fractional screen distance ('s'), and
+        pulsar distance in kpc ('d'). Note that 'KOM' is required even
+        for non-binary pulsars, since it is used unconditionally to
+        rotate the pulsar/proper-motion velocity into RA/Dec.
+    true_anomaly : numpy.ndarray
+        True anomalies to compute over (radians). Ignored if the
+        binary parameters are absent from `params`.
+    vearth_ra : numpy.ndarray
+        Earth velocity in RA to compute over (km/s).
+    vearth_dec : numpy.ndarray
+        Earth velocity in Dec to compute over (km/s).
+    mjd : numpy.ndarray or float, optional
+        MJDs corresponding to `true_anomaly`, used to evaluate the
+        'OMDOT' correction to the longitude of periastron. Default is
+        None; if 'OMDOT' is present in `params` and `mjd` is None, a
+        warning is printed and the uncorrected 'OM' is used.
+
+    Returns
+    -------
+    veff_ra : numpy.ndarray
+        Total effective velocity in RA (km/s), combining the Earth
+        and pulsar/proper-motion contributions weighted by the
+        fractional screen distance.
+    veff_dec : numpy.ndarray
+        Total effective velocity in Dec (km/s).
+    vp_ra : numpy.ndarray or float
+        Pulsar orbital velocity in RA (km/s); 0 if no binary
+        parameters are present.
+    vp_dec : numpy.ndarray or float
+        Pulsar orbital velocity in Dec (km/s); 0 if no binary
+        parameters are present.
     """
     # Define some constants
     v_c = 299792.458  # km/s
@@ -589,21 +1098,28 @@ def effective_velocity_annual(params, true_anomaly, vearth_ra, vearth_dec,
 
 def arc_weak(ftn, ar=1, psi=0, alpha=11/3):
     """
+    Model the 1D weak-scattering scintillation arc Doppler profile
+    (power vs normalised Doppler frequency), for a possibly
+    anisotropic scattering screen.
+
     Parameters
     ----------
-    ftn : Array 1D
-        The normalised Doppler frequency (x-axis), where ftn=1 is the arc
-
+    ftn : array_like, 1D
+        The normalised Doppler frequency (x-axis), where ``ftn = 1``
+        is the arc.
     ar : float, optional
-        Anisotropy axial ratio. The default is 1.
+        Anisotropy axial ratio. The default is 1 (isotropic).
     psi : float, optional
-        DESCRIPTION. The default is 0.
+        Orientation angle of the anisotropy, in degrees. The default
+        is 0.
+    alpha : float, optional
+        Index of the turbulence spectrum. The default is 11/3
+        (Kolmogorov).
 
     Returns
     -------
-    p : Array 1D
-        The model poppler profile
-
+    p : array_like, 1D
+        The model Doppler profile.
     """
 
     # Begin model
@@ -620,27 +1136,35 @@ def arc_weak(ftn, ar=1, psi=0, alpha=11/3):
 
 def arc_weak_2d(fdop, tdel, eta=1, ar=1, psi=0, alpha=11/3):
     """
+    Model the 2D weak-scattering secondary spectrum along a
+    scintillation arc, for a possibly anisotropic scattering screen.
+
     Parameters
     ----------
-    fdop : Array 1D
-        The Doppler frequency (x-axis) coordinates of the model secondary
+    fdop : array_like, 1D
+        The Doppler frequency (x-axis) coordinates of the model
+        secondary spectrum.
+    tdel : array_like, 1D
+        The delay (y-axis) coordinates of the model secondary
         spectrum.
-    tdel : Array 1D
-        The wavenumber (y-axis) coordinates of the model secondary spectrum.
-    eta : floar, optional
+    eta : float, optional
         Arc curvature. The default is 1.
     ar : float, optional
-        Anisotropy axial ratio. The default is 1.
+        Anisotropy axial ratio. The default is 1 (isotropic).
     psi : float, optional
-        DESCRIPTION. The default is 0.
+        Orientation angle of the anisotropy, in degrees. The default
+        is 0.
     alpha : float, optional
-        DESCRIPTION. The default is 11/3.
+        Index of the turbulence spectrum. The default is 11/3
+        (Kolmogorov). Note that, unlike in `arc_weak`, this parameter
+        is currently unused by the model, which always uses a fixed
+        exponent of -11/6 (appropriate for Kolmogorov turbulence).
 
     Returns
     -------
-    sspec : Array 2D
-        The model secondary spectrum.
-
+    sspec : array_like, 2D
+        The model secondary spectrum, with shape
+        ``(len(tdel), len(fdop))``.
     """
 
     # Begin model

--- a/scintools/scint_models.py
+++ b/scintools/scint_models.py
@@ -209,6 +209,7 @@ def tau_acf_model(params, xdata, ydata, weights):
     alpha = parvals['alpha']
 
     model = amp*np.exp(-np.divide(xdata, tau)**(alpha))
+    weights = np.array(weights, dtype=float)  # copy so caller is not mutated
     weights[0] = 0  # Not fitting for the white noise spike
     # Multiply by triangle function
     model = np.multiply(model, 1-np.divide(xdata, max(xdata)))
@@ -255,6 +256,7 @@ def dnu_acf_model(params, xdata, ydata, weights):
     dnu = parvals['dnu']
 
     model = amp*np.exp(-np.divide(xdata, dnu/np.log(2)))
+    weights = np.array(weights, dtype=float)  # copy so caller is not mutated
     weights[0] = 0  # Not fitting for the white noise spike
     # Multiply by triangle function
     model = np.multiply(model, 1-np.divide(xdata, max(xdata)))
@@ -453,7 +455,7 @@ def scint_acf_model_2d(params, ydata, weights):
     return (ydata - model) * weights
 
 
-def tau_sspec_model(params, xdata, ydata):
+def tau_sspec_model(params, xdata, ydata, weights=None):
     """
     Model a 1D cut through the center of the ACF along the time axis
     and apply a Fourier transform, returning the residuals against
@@ -496,11 +498,13 @@ def tau_sspec_model(params, xdata, ydata):
     model = np.real(model)
     model = model[0:len(xdata)]
 
-    # Use the model for the weights
-    return (ydata - model) * model
+    # Use the model for the weights unless explicit weights are provided
+    if weights is None:
+        weights = model
+    return (ydata - model) * weights
 
 
-def dnu_sspec_model(params, xdata, ydata):
+def dnu_sspec_model(params, xdata, ydata, weights=None):
     """
     Model a 1D cut through the center of the ACF along the frequency
     axis and apply a Fourier transform, returning the residuals
@@ -544,8 +548,10 @@ def dnu_sspec_model(params, xdata, ydata):
     model = np.real(model)
     model = model[0:len(xdata)]
 
-    # Use the model for the weights
-    return (ydata - model) * model
+    # Use the model for the weights unless explicit weights are provided
+    if weights is None:
+        weights = model
+    return (ydata - model) * weights
 
 
 def scint_sspec_model(params, xdata, ydata, weights):
@@ -570,8 +576,8 @@ def scint_sspec_model(params, xdata, ydata, weights):
         through to `tau_sspec_model` and `dnu_sspec_model`
         respectively.
     weights : sequence
-        Two-element sequence ``(weights_t, weights_f)``, passed as an
-        extra positional argument to `tau_sspec_model` and
+        Two-element sequence ``(weights_t, weights_f)``, passed as the
+        optional ``weights`` argument to `tau_sspec_model` and
         `dnu_sspec_model`.
 
     Returns
@@ -579,14 +585,6 @@ def scint_sspec_model(params, xdata, ydata, weights):
     numpy.ndarray
         Concatenation of the residuals from `tau_sspec_model` and
         `dnu_sspec_model`.
-
-    Raises
-    ------
-    TypeError
-        `tau_sspec_model` and `dnu_sspec_model` only accept
-        ``(params, xdata, ydata)``, so calling them here with an
-        extra `weights` element currently raises a TypeError. This
-        function is not presently called elsewhere in the package.
     """
 
     residuals_t = tau_sspec_model(params, xdata[0], ydata[0], weights[0])
@@ -618,19 +616,18 @@ def arc_power_curve(params, xdata, ydata, weights):
     numpy.ndarray
         Weighted residual of model and data.
 
-    Notes
-    -----
-    The model template is not yet implemented: `model` is currently
-    an empty list, so ``ydata - model`` will raise a
-    ``ValueError`` (mismatched shapes) for any non-empty `ydata`.
-    This function is not presently called elsewhere in the package.
+    Raises
+    ------
+    NotImplementedError
+        The power-curve template has not been implemented yet. This
+        function is not presently called elsewhere in the package;
+        calling it raises `NotImplementedError` rather than silently
+        returning meaningless residuals.
     """
 
-    if weights is None:
-        weights = np.ones(np.shape(ydata))
-
-    model = []
-    return (ydata - model) * weights
+    raise NotImplementedError(
+        'arc_power_curve is not yet implemented: no power-curve template '
+        'has been defined.')
 
 
 def fit_parabola(x, y):
@@ -1045,8 +1042,8 @@ def effective_velocity_annual(params, true_anomaly, vearth_ra, vearth_dec,
         elif 'SINI' in params.keys():
             INC = np.arcsin(params['SINI'])
         else:
-            print('Warning: inclination parameter (KIN, COSI, or SINI) ' +
-                  'not found')
+            raise KeyError('inclination parameter (KIN, COSI, or SINI) '
+                           'not found')
 
         if 'sense' in params.keys():
             sense = params['sense']

--- a/scintools/scint_sim.py
+++ b/scintools/scint_sim.py
@@ -214,7 +214,7 @@ class Simulation():
         L = self.rf**2 * k
         # Curvature to use for Dynspec object within scintools
         self.eta = L/(2 * V**2) / 10**6 / np.cos(psi * np.pi/180)**2
-        c = 299792458.0  # m/s
+        c = sc.c  # m/s (speed of light)
         beta_to_eta = c*1e6/((self.freq*10**6)**2)
         # Curvature for wavelength-rescaled dynamic spectrum
         self.betaeta = self.eta / beta_to_eta

--- a/scintools/scint_sim.py
+++ b/scintools/scint_sim.py
@@ -653,7 +653,7 @@ class Simulation():
                        (np.arange(0, 3*self.nf/2, 1) - self.nf/2) /
                        (2*self.dlam*Freq),
                        lpw[int(self.nf/2):, :], vmin=vmin, vmax=vmax)
-        plt.colorbar
+        plt.colorbar()
         plt.ylabel('Delay (ns)')
         plt.xlabel('$x/r_f$')
         plt.plot(np.linspace(0, self.dx*self.nx, self.nx),
@@ -911,7 +911,8 @@ class ACF():
             tn = np.linspace(0, (spmax), int(np.ceil(self.nt/2)))
             snx = Vx*tn
             sny = Vy*tn
-            gammitv = np.zeros((int(len(snx)), int(ndnun)), dtype=np.complex_)
+            gammitv = np.zeros((int(len(snx)), int(ndnun)),
+                               dtype=np.complex128)
             # compute dnun=0 first
             gammitv[:, 0] = np.exp(-0.5*((snx/sqrtar)**2 +
                                          (sny*sqrtar)**2)**alph2)
@@ -956,7 +957,8 @@ class ACF():
             snx = np.cos(xi*np.pi/180)*tn
             sny = np.sin(xi*np.pi/180)*tn
             # compute dnun=0 first
-            gammitv = np.zeros((int(len(snx)), int(ndnun)), dtype=np.complex_)
+            gammitv = np.zeros((int(len(snx)), int(ndnun)),
+                               dtype=np.complex128)
             gammitv[:, 0] = np.exp(-0.5*((snx/sqrtar)**2 +
                                          (sny*sqrtar)**2)**alph2)
             gammitv[np.argwhere(snx == 0), 0] += wn/amp

--- a/scintools/scint_sim.py
+++ b/scintools/scint_sim.py
@@ -1,9 +1,25 @@
 #!/usr/bin/env python
 
 """
-scintsim.py
+scint_sim.py
 ----------------------------------
-Simulate scintillation. Based on original MATLAB code by Coles et al. (2010)
+Simulation tools for pulsar scintillation.
+
+This module provides three classes:
+
+* `Simulation` - a wave-optics simulator of a thin scattering screen that
+  produces a simulated dynamic spectrum (and related products such as the
+  phase screen, electric field, and scatter-broadened pulse shape). Based on
+  original MATLAB code by Coles et al. (2010), "Scattering of pulsar radio
+  emission by the interstellar plasma".
+* `ACF` - computes the theoretical autocorrelation function (ACF) and
+  secondary spectrum of intensity for strong scintillation, following the
+  analytic treatment in Appendix A of Rickett, Coles et al. (2014), ApJ 787,
+  161.
+* `Brightness` - computes the angular brightness distribution, delay-Doppler
+  (secondary) spectrum, and ACF of a scattered wave from the angular
+  spectrum, based on Yao et al. (2020) with corrections to the phase
+  gradient terms.
 """
 
 from __future__ import (absolute_import, division,
@@ -21,6 +37,16 @@ from scintools.scint_utils import is_valid, get_window
 
 
 class Simulation():
+    """
+    Wave-optics simulator of a thin scattering screen.
+
+    Generates a random phase screen with a given power-law structure
+    function and anisotropy, propagates it through the Fresnel diffraction
+    integral to obtain the electric field and intensity as a function of
+    observer position and frequency, and packages the result as a simulated
+    dynamic spectrum (with physical time/frequency axes) for use elsewhere
+    in scintools. Based on original MATLAB code by Coles et al. (2010).
+    """
 
     def __init__(self, mb2=2, rf=1, ds=0.01, alpha=5/3, ar=1, psi=0,
                  inner=0.001, ns=256, nf=256, dlam=0.25, lamsteps=False,
@@ -28,20 +54,81 @@ class Simulation():
                  verbose=False, freq=1400, dt=30, mjd=60000, nsub=None,
                  efield=False, noise=None):
         """
-        Electromagnetic simulator based on original code by Coles et al. (2010)
+        Electromagnetic simulator based on original code by Coles et al.
+        (2010).
 
-        mb2: Max Born parameter for strength of scattering
-        rf: Fresnel scale
-        ds (or dx,dy): Spatial step sizes with respect to rf
-        alpha: Structure function exponent (Kolmogorov = 5/3)
-        ar: Anisotropy axial ratio
-        psi: Anisotropy orientation
-        inner: Inner scale w.r.t rf - should generally be smaller than ds
-        ns (or nx,ny): Number of spatial steps
-        nf: Number of frequency steps.
-        dlam: Fractional bandwidth relative to centre frequency
-        lamsteps: Boolean to choose whether steps in lambda or freq
-        seed: Seed number, or use "-1" to shuffle
+        On construction, this generates the phase screen, propagates it to
+        get the electric field and intensity, computes the dynamic spectrum
+        (if ``nf > 1``), and computes the scatter-broadened pulse response.
+        The result is stored as ``self.dyn`` with physical axes
+        (``self.freqs``, ``self.times``) so that a `Simulation` instance can
+        be passed directly to scintools' `Dynspec` class.
+
+        Parameters
+        ----------
+        mb2 : float, optional
+            Max Born parameter, sets the strength of scattering.
+        rf : float, optional
+            Fresnel scale, used as the length unit for the simulation.
+        ds : float, optional
+            Spatial step size (in units of `rf`), used for both x and y
+            unless overridden by `dx`/`dy`.
+        alpha : float, optional
+            Structure function exponent (Kolmogorov turbulence = 5/3).
+        ar : float, optional
+            Axial ratio of the anisotropy of the scattering screen.
+        psi : float, optional
+            Orientation angle (degrees) of the anisotropy.
+        inner : float, optional
+            Inner scale of turbulence, in units of `rf`. Should generally be
+            smaller than `ds`.
+        ns : int, optional
+            Number of spatial steps in x and y, used unless overridden by
+            `nx`/`ny`.
+        nf : int, optional
+            Number of frequency steps across the fractional bandwidth
+            `dlam`.
+        dlam : float, optional
+            Fractional bandwidth relative to the centre frequency.
+        lamsteps : bool, optional
+            If True, take equally-spaced steps in wavelength rather than in
+            frequency.
+        seed : int or None, optional
+            Seed for the random phase screen, for reproducible simulations.
+            Use -1 to reshuffle (i.e. use a fresh, unseeded draw). Default
+            of None uses NumPy's global random state.
+        nx : int or None, optional
+            Number of spatial steps in x. Overrides `ns` when set.
+        ny : int or None, optional
+            Number of spatial steps in y. Overrides `ns` when set.
+        dx : float or None, optional
+            Spatial step size in x (in units of `rf`). Overrides `ds` when
+            set.
+        dy : float or None, optional
+            Spatial step size in y (in units of `rf`). Overrides `ds` when
+            set.
+        plot : bool, optional
+            If True, plot the screen, intensity, and dynamic spectrum after
+            the simulation is computed (calls `plot_all`).
+        verbose : bool, optional
+            If True, print progress messages while the simulation runs.
+        freq : float, optional
+            Centre observing frequency, in MHz, used to set the physical
+            frequency axis of the simulated dynamic spectrum.
+        dt : float, optional
+            Subintegration time, in seconds, used to set the physical time
+            axis of the simulated dynamic spectrum.
+        mjd : float, optional
+            MJD of the start of the observation, recorded in the header.
+        nsub : int or None, optional
+            Number of subintegrations (spatial steps in x) to keep in the
+            output dynamic spectrum. If None, all `nx` steps are kept.
+        efield : bool, optional
+            If True, store the (real part of the) electric field instead of
+            the intensity in ``self.dyn``.
+        noise : float or None, optional
+            Noise level parameter, accepted for interface compatibility.
+            Currently unused within this method.
         """
 
         self.mb2 = mb2
@@ -135,7 +222,16 @@ class Simulation():
         return
 
     def set_constants(self):
+        """
+        Precompute constants used by the simulation.
 
+        Derives the Fresnel-filter constants (`ffconx`, `ffcony`), the
+        spatial coherence scale (`s0`), the normalization of the phase
+        power spectrum (`consp`), the FFT normalization (`scnorm`), and the
+        reference scale (`sref`) from the current values of `nx`, `ny`,
+        `dx`, `dy`, `alpha`, `mb2`, and `rf`. Sets these as attributes on
+        the instance; does not return a value.
+        """
         ns = 1
         lenx = self.nx*self.dx
         leny = self.ny*self.dy
@@ -207,6 +303,29 @@ class Simulation():
         return
 
     def get_intensity(self, verbose=True):
+        """
+        Propagate the phase screen to the observer plane at each frequency.
+
+        For each of the `nf` frequency channels, applies the appropriate
+        Fresnel scaling to the phase screen, propagates it via the Fresnel
+        filter (`frfilt3`), and takes a 1D cut through the resulting
+        electric field (through the centre row in y) as a function of x.
+        Requires `get_screen` to have been run first (i.e. `self.xyp` to
+        exist).
+
+        Parameters
+        ----------
+        verbose : bool, optional
+            If True, print progress as a percentage while looping over
+            frequency channels.
+
+        Returns
+        -------
+        None
+            Sets ``self.xyi`` (intensity of the last-computed frequency's
+            2D field) and ``self.spe`` (complex electric field as a
+            function of x and frequency) as attributes.
+        """
         spe = np.zeros([self.nx, self.nf],
                        dtype=np.dtype(np.csingle)) + \
             1j*np.zeros([self.nx, self.nf],
@@ -236,6 +355,21 @@ class Simulation():
         return
 
     def get_dynspec(self):
+        """
+        Compute the dynamic spectrum (intensity) from the electric field.
+
+        Requires `get_intensity` to have been run first (i.e. `self.spe`
+        to exist). Also computes the spatial x-axis (`self.x`) and the
+        normalized wavelength (`self.lams`) and frequency (`self.freqs`)
+        axes across the fractional bandwidth.
+
+        Returns
+        -------
+        None
+            Sets ``self.spi`` (dynamic spectrum, intensity vs x and
+            frequency), ``self.x``, ``self.lams``, and ``self.freqs`` as
+            attributes.
+        """
         if self.nf == 1:
             print('no spectrum because nf=1')
 
@@ -274,6 +408,27 @@ class Simulation():
         self.dm = self.xyp[:, int(self.ny/2)]*self.dlam/np.pi
 
     def swdsp(self, kx=0, ky=0):
+        """
+        Amplitude of the phase-screen power spectrum at given wavenumbers.
+
+        Evaluates the square root of the (anisotropic, power-law) phase
+        power spectral density, including the isotropic inner-scale
+        cutoff, at the wavenumber(s) `(kx, ky)`. Used by `get_screen` to
+        build the phase screen from a complex Gaussian random field.
+
+        Parameters
+        ----------
+        kx : float or numpy.ndarray, optional
+            Wavenumber(s) in the x direction.
+        ky : float or numpy.ndarray, optional
+            Wavenumber(s) in the y direction.
+
+        Returns
+        -------
+        float or numpy.ndarray
+            Amplitude weighting to apply at `(kx, ky)`, same shape as the
+            broadcast of `kx` and `ky`.
+        """
         cs = np.cos(self.psi*np.pi/180)
         sn = np.sin(self.psi*np.pi/180)
         r = self.ar
@@ -292,6 +447,29 @@ class Simulation():
         return out
 
     def frfilt3(self, xye, scale):
+        """
+        Apply the Fresnel-propagation filter to a 2D field, in place.
+
+        Multiplies the four quadrants of the 2D Fourier-domain field `xye`
+        by the appropriate Fresnel phase factor (a function of wavenumber
+        and `scale`), using the Fresnel-filter constants (`ffconx`,
+        `ffcony`) computed by `set_constants`.
+
+        Parameters
+        ----------
+        xye : numpy.ndarray
+            2D complex array (Fourier transform of the field) to filter,
+            of shape ``(nx, ny)``. Modified in place.
+        scale : float
+            Fresnel scaling factor for the current frequency channel
+            (relative wavelength/frequency scale).
+
+        Returns
+        -------
+        numpy.ndarray
+            The filtered array (the same object as `xye`, modified in
+            place).
+        """
         nx2 = int(self.nx / 2) + 1
         ny2 = int(self.ny / 2) + 1
         filt = np.zeros([nx2, ny2], dtype=np.dtype(np.csingle))
@@ -311,6 +489,19 @@ class Simulation():
         return xye
 
     def plot_screen(self, subplot=False):
+        """
+        Plot the simulated phase screen in x and y.
+
+        Computes the screen first via `get_screen` if it has not already
+        been computed.
+
+        Parameters
+        ----------
+        subplot : bool, optional
+            If True, draw onto the current axes without calling
+            ``plt.show()`` (for use as part of a larger figure, e.g. by
+            `plot_all`). If False, show the figure immediately.
+        """
         if not hasattr(self, 'xyp'):
             self.get_screen()
         x_steps = np.linspace(0, self.dx*self.nx, self.nx)
@@ -324,7 +515,20 @@ class Simulation():
         return
 
     def plot_intensity(self, subplot=False):
-        # routine to plot intensity
+        """
+        Plot the observer-side intensity fluctuations in space, at the
+        centre frequency.
+
+        Computes the intensity first via `get_intensity` if it has not
+        already been computed.
+
+        Parameters
+        ----------
+        subplot : bool, optional
+            If True, draw onto the current axes without calling
+            ``plt.show()`` (for use as part of a larger figure, e.g. by
+            `plot_all`). If False, show the figure immediately.
+        """
         if not hasattr(self, 'xyi'):
             self.get_intensity()
         x_steps = np.linspace(0, self.dx*(self.nx), (self.nx))
@@ -338,6 +542,20 @@ class Simulation():
         return
 
     def plot_dynspec(self, subplot=False):
+        """
+        Plot the simulated dynamic spectrum (intensity vs x and
+        frequency/wavelength).
+
+        Computes the dynamic spectrum first via `get_dynspec` if it has
+        not already been computed.
+
+        Parameters
+        ----------
+        subplot : bool, optional
+            If True, draw onto the current axes without calling
+            ``plt.show()`` (for use as part of a larger figure, e.g. by
+            `plot_all`). If False, show the figure immediately.
+        """
         if not hasattr(self, 'spi'):
             self.get_dynspec()
 
@@ -354,6 +572,19 @@ class Simulation():
         return
 
     def plot_efield(self, subplot=False):
+        """
+        Plot the real part of the simulated electric field vs x and
+        frequency/wavelength.
+
+        Computes the electric field first via `get_intensity` if it has
+        not already been computed.
+
+        Parameters
+        ----------
+        subplot : bool, optional
+            If True, draw onto the current axes without calling
+            ``plt.show()``. If False, show the figure immediately.
+        """
         if not hasattr(self, 'spe'):
             self.get_intensity()
 
@@ -372,6 +603,19 @@ class Simulation():
         return
 
     def plot_delay(self, subplot=False):
+        """
+        Plot the dispersive group delay vs x (at the centre frequency) and
+        the pulse-averaged impulse response function vs delay.
+
+        Requires `get_pulse` to have been run first (i.e. `self.dm` and
+        `self.pulsewin` to exist).
+
+        Parameters
+        ----------
+        subplot : bool, optional
+            Accepted for interface consistency with the other ``plot_*``
+            methods; currently unused (the figure is always shown).
+        """
         # get frequency to set the scale, enter in GHz
         Freq = self.freq/1000
         plt.subplot(2, 1, 1)
@@ -387,6 +631,19 @@ class Simulation():
         return
 
     def plot_pulse(self, subplot=False):
+        """
+        Plot the (log) intensity of the scatter-broadened pulse vs x and
+        delay, overlaid with the group delay from the phase screen.
+
+        Requires `get_pulse` to have been run first (i.e. `self.dm` and
+        `self.pulsewin` to exist).
+
+        Parameters
+        ----------
+        subplot : bool, optional
+            Accepted for interface consistency with the other ``plot_*``
+            methods; currently unused (the figure is always shown).
+        """
         # get frequency to set the scale, enter in GHz
         Freq = self.freq/1000
         lpw = np.log10(self.pulsewin)
@@ -404,6 +661,10 @@ class Simulation():
         plt.show()
 
     def plot_all(self):
+        """
+        Plot the phase screen, intensity, and dynamic spectrum together as
+        subplots in a single figure.
+        """
         plt.figure(2)
         plt.subplot(2, 2, 1)
         self.plot_screen(subplot=True)
@@ -415,37 +676,82 @@ class Simulation():
 
 
 class ACF():
+    """
+    Theoretical autocorrelation function (ACF) of scintillation intensity.
+
+    Computes the 2D ACF of intensity vs time and frequency (and the
+    corresponding secondary spectrum) directly from the theoretical
+    function for strong scintillation given in Appendix A of Rickett,
+    Coles et al. (2014), ApJ 787, 161, including the effects of
+    anisotropy and a phase gradient (e.g. due to a binary companion).
+    The magnitude of the effective velocity is defined to be 1, so time
+    and frequency lags are expressed in units of the (isotropic)
+    scintillation timescale and decorrelation bandwidth respectively.
+    """
 
     def __init__(self, psi=0, phasegrad=0, theta=0, ar=1, alpha=5/3,
                  taumax=4, dnumax=4, nf=51, nt=51, amp=1, wn=0,
                  spatial_factor=2, resolution_factor=1, core_factor=2,
                  auto_sampling=True, plot=False, display=True):
         """
-        Generate an ACF from the theoretical function in:
-            Rickett et al. (2014)
+        Generate an ACF from the theoretical function in Rickett, Coles et
+        al. (2014).
 
-        Magnitude of velocity defined to be 1
+        Magnitude of velocity is defined to be 1. On construction, this
+        computes the ACF via `calc_acf`.
 
-        psi - angle of velocity w.r.t the major axis of (brightness) anisotropy
-        phasegrad - magnitude of phase gradient
-        theta - angle of phase gradient w.r.t velocity vector
-        ar - axial ratio of anisotropy
-        alpha - structure function exponent (Kolmogorov = 5/3)
-        taumax - number of time scales to calculate ACF to
-            (ACF in space goes to taumax*V)
-        dnumax - number of frequency scales to calculate ACF to
-        nf - size of ACF in frequency. If not odd, returns nf+1
-        nt - size of ACF in frequency. If not odd, returns nt+1
-        amp - amplitude of ACF
-        wn - size of white-noise spike at the origin of ACF
-        spatial_factor - multiplier for spmax for calculating ACF e-field
-        resolution_factor - multiplier to default resolution for ACF e-field
-        core_factor - additional resolution multiplier for the first dnu sample
-        auto_sampling - (bool) decide whether to adjust spatial sampling
-            automatically to avoid artefacts.
-            Warning: computation time blows up for large ar
-        plot - (bool) choose whether to plot after computing
-        display - (bool) choose whether to display to screen immediately
+        Parameters
+        ----------
+        psi : float, optional
+            Angle (degrees) of the velocity vector with respect to the
+            major axis of the (brightness) anisotropy.
+        phasegrad : float, optional
+            Magnitude of the phase gradient (e.g. due to a binary
+            companion).
+        theta : float, optional
+            Angle (degrees) of the phase gradient with respect to the
+            velocity vector.
+        ar : float, optional
+            Axial ratio of the anisotropy.
+        alpha : float, optional
+            Structure function exponent (Kolmogorov turbulence = 5/3).
+        taumax : float, optional
+            Number of scintillation timescales to compute the ACF out to
+            (equivalently, the ACF in space goes out to ``taumax*V``).
+        dnumax : float, optional
+            Number of decorrelation bandwidths to compute the ACF out to.
+        nf : int, optional
+            Number of frequency lag samples in the ACF. If not odd, it is
+            incremented by one so the ACF has a well-defined centre.
+        nt : int, optional
+            Number of time lag samples in the ACF. If not odd, it is
+            incremented by one so the ACF has a well-defined centre.
+        amp : float, optional
+            Amplitude to scale the ACF by.
+        wn : float, optional
+            Size of the white-noise spike at the origin of the ACF.
+        spatial_factor : float, optional
+            Multiplier for the spatial extent (`taumax`) used when
+            calculating the ACF of the electric field. Only used if
+            `auto_sampling` is False.
+        resolution_factor : float, optional
+            Multiplier applied to the default spatial resolution used when
+            calculating the ACF of the electric field. Only used if
+            `auto_sampling` is False.
+        core_factor : float, optional
+            Additional resolution multiplier applied near the origin
+            (first frequency-lag sample), where the integrand varies most
+            rapidly. Only used if `auto_sampling` is False.
+        auto_sampling : bool, optional
+            If True, automatically set the spatial sampling factors
+            (`sp_fac`, `res_fac`, `core_fac`) based on `ar` and `taumax`,
+            to avoid sampling artefacts, overriding `spatial_factor`,
+            `resolution_factor`, and `core_factor`. Warning: computation
+            time increases sharply for large `ar`.
+        plot : bool, optional
+            If True, plot the ACF after it is computed.
+        display : bool, optional
+            If True and `plot` is True, show the plot immediately.
         """
 
         self.alpha = alpha
@@ -492,47 +798,66 @@ class ACF():
         return
 
     def calc_acf(self, plot=False):
-        """
-        Computes 2D ACF of intensity vs time and frequency where the
-        sampling in the output ACF can be handled automatically.
+        r"""
+        Compute the 2D ACF of intensity vs time and frequency.
 
-        requires anisotropy and angular displacement due to phase gradient.
-        psi = 0, defines brightness distribution anisotropy aligned with V
-        theta = 0, defines phase gradient aligned with V
-        (Within the code, x-axis (see Vx, and sigxn parameters) is the major
-         axis of ACF-efield anisotropy, which is psi=90)
+        Implements the integrals in Appendix A of Rickett, Coles et al.
+        (2014) (equations A1 and A2) for the ACF of intensity, given the
+        anisotropy and the angular displacement due to any phase gradient.
+        ``psi = 0`` defines the brightness-distribution anisotropy as
+        aligned with the velocity V; ``theta = 0`` defines the phase
+        gradient as aligned with V. (Within the code, the x-axis, see the
+        `Vx` and `sigxn` variables, is the major axis of the ACF-efield
+        anisotropy, which corresponds to ``psi=90``.)
 
-        implements the integrals in Appendix A of Rickett, Coles et al ApJ 2014
-        on the analysis of the double pulsar scintillation equations A1 and A2.
-        A2 has an error. It would be correct if nu were replaced by omega,
-        i.e. had an extra 2*pi
+        Coordinates in the code are with respect to the `ar` major axis,
+        so the structure itself does not need to be rotated; instead V and
+        the phase gradient are rotated into the structure coordinates.
+        The spatial lag ``sn`` is normalized by :math:`s_0` and the
+        frequency lag ``dnun`` by :math:`\nu_{0.5}`, the spatial and
+        frequency scales respectively; the phase gradient is normalized by
+        :math:`1/s_0` (i.e. ``sigxn = gradphix * s0``).
 
-        coordinates in the code are with respect to ar major axis so we don't
-        have to rotate the structure, we put V and phasegrad into the
-        structure coordinates.
+        Parameters
+        ----------
+        plot : bool, optional
+            If True, plot the resulting ACF (via `plot_acf`) after it is
+            computed.
 
-        The distance sn is normalized by So and the frequency dnun by \nu_{0.5}
-        the spatial scale and the frequency scale respectively.
-        the phase gradient is normalized by the 1/s0,
-        i.e. sigxn = gradphix * s0
+        Returns
+        -------
+        None
+            Sets ``self.acf`` (2D ACF of intensity), ``self.tn`` (time-lag
+            axis), ``self.fn`` (frequency-lag axis), ``self.sn``
+            (equivalent to ``self.tn``), ``self.snp`` (spatial-lag axis of
+            the electric-field ACF), and ``self.acf_efield`` (ACF of the
+            electric field) as attributes.
 
-        if there is no phase gradient then the acf is symmetric and only one
-        quadrant needs to be calculated. Otherwise two quadrants are necessary.
+        Notes
+        -----
+        If there is no phase gradient, the ACF is symmetric and only one
+        quadrant needs to be calculated; otherwise two quadrants are
+        necessary.
 
-        the worst case sampling is when dnun is very small. Then the argument
-        of the complex exponential becomes large and aliasing will occur. If
-        dnun=0.01 and dsp=0.1 the alias will peak at snx = 5. Reducing the
-        sampling dsp to 0.05 will push that alias out to snx = 8. However
-        halving dsp will increase the time by a factor of 4. Sampling
-        characteristics can be tuned with spatial_factor, resolution_factor,
-        and core_factor parameters
+        The worst-case sampling is when ``dnun`` is very small: the
+        argument of the complex exponential becomes large and aliasing
+        will occur. If ``dnun=0.01`` and ``dsp=0.1``, the alias will peak
+        at ``snx = 5``; reducing the spatial sampling ``dsp`` to 0.05 will
+        push that alias out to ``snx = 8``, though halving ``dsp``
+        increases the computation time by a factor of 4. Sampling can be
+        tuned via the `spatial_factor`, `resolution_factor`, and
+        `core_factor` parameters of `__init__` (or `auto_sampling`).
 
-        The frequency decorrelation is quite linear near the origin and looks
-        quasi-exponential, the 0.5 width is dnun = 0.15. Sampling of 0.05 is
-        more than adequate in frequency. Sampling of 0.1 in sn is adequate
+        The frequency decorrelation is quite linear near the origin and
+        looks quasi-exponential; the half-power width is ``dnun = 0.15``,
+        so a sampling of 0.05 in frequency is more than adequate, and a
+        sampling of 0.1 in ``sn`` is adequate. ``dnun = 0.0`` is divergent
+        in this integral, but is obtained trivially from the ACF of the
+        electric field directly.
 
-        dnun = 0.0 is divergent with this integral but can be obtained
-        trivially from the ACF of the electric field directly
+        Note also that Rickett, Coles et al. (2014) equation A2 as printed
+        has an error: it would be correct if :math:`\nu` were replaced by
+        :math:`\omega`, i.e. with an extra factor of :math:`2\pi`.
         """
 
         alph2 = self.alpha/2
@@ -679,7 +1004,23 @@ class ACF():
 
     def plot_acf(self, display=True, contour=True, filled=False):
         """
-        Plots the simulated ACF
+        Plot the theoretical 2D ACF of intensity vs time and frequency
+        lag.
+
+        Requires `calc_acf` to have been run first (i.e. `self.acf`,
+        `self.tn`, `self.fn` to exist).
+
+        Parameters
+        ----------
+        display : bool, optional
+            If True, set the plot title and call ``plt.show()``
+            immediately.
+        contour : bool, optional
+            If True and `filled` is False, overlay black contours at
+            ``amp * [0.2, 0.4, 0.6, 0.8]``.
+        filled : bool, optional
+            If True, plot filled contours (``plt.contourf``) instead of a
+            pcolormesh.
         """
         # for plotting, we need to expand tn and fn,
         #   since they are pixel edges, not centres
@@ -710,7 +1051,15 @@ class ACF():
 
     def plot_acf_efield(self, display=True):
         """
-        Plots the simulated ACF
+        Plot the ACF of the electric field vs spatial lag.
+
+        Requires `calc_acf` to have been run first (i.e. `self.acf_efield`
+        and `self.snp` to exist).
+
+        Parameters
+        ----------
+        display : bool, optional
+            If True, call ``plt.show()`` immediately.
         """
         # for plotting, we need to expand tn and fn,
         #   since they are pixel edges, not centres
@@ -727,7 +1076,26 @@ class ACF():
 
     def calc_sspec(self, window='hanning', window_frac=1):
         """
-        Calculate the secondary spectrum
+        Compute the secondary spectrum from the ACF.
+
+        Applies a 2D window to the ACF (`self.acf`) before taking its 2D
+        Fourier transform, to reduce edge effects/spectral leakage.
+
+        Parameters
+        ----------
+        window : str, optional
+            Name of the window function to apply along each axis before
+            transforming (passed to `scintools.scint_utils.get_window`),
+            e.g. 'hanning', 'blackman'.
+        window_frac : float, optional
+            Fraction of each axis over which the window is applied
+            (passed to `scintools.scint_utils.get_window`).
+
+        Returns
+        -------
+        None
+            Sets ``self.sspec`` (secondary spectrum, in dB) as an
+            attribute.
         """
         nf, nt = np.shape(self.acf)
         chan_window, subint_window = get_window(nt, nf, window=window,
@@ -743,7 +1111,24 @@ class ACF():
 
     def plot_sspec(self, display=True, vmin=None, vmax=None):
         """
-        Plots the simulated ACF
+        Plot the secondary spectrum vs time and frequency lag.
+
+        Computes the secondary spectrum first via `calc_sspec` (with its
+        default window) if it has not already been computed.
+
+        Parameters
+        ----------
+        display : bool, optional
+            If True, set the plot title and call ``plt.show()``
+            immediately.
+        vmin : float or None, optional
+            Minimum of the colour scale, in dB. If None, defaults to 3 dB
+            below the median of the (finite, non-zero) secondary
+            spectrum.
+        vmax : float or None, optional
+            Maximum of the colour scale, in dB. If None, defaults to 3 dB
+            below the maximum of the (finite, non-zero) secondary
+            spectrum.
         """
         if not hasattr(self, 'sspec'):
             self.calc_sspec()
@@ -766,39 +1151,101 @@ class ACF():
 
 
 class Brightness():
+    """
+    Angular brightness distribution and delay-Doppler (secondary) spectrum
+    of a scattered wave interfering with an unscattered wave.
+
+    Based on Yao et al. (2020), modified to correctly account for the
+    phase gradient terms and to remove spurious bright points in the
+    secondary spectrum (caused by a coordinate singularity) that would
+    otherwise create artefacts in the ACF. The angular spectrum is
+    defined by the (phase) structure function exponent. The ACF of the
+    electric field is calculated first and 2D-FFT'ed to get the
+    brightness distribution; the brightness distribution can then be
+    offset by a phase gradient, which causes an angular shift as a
+    fraction of the half-width of the distribution.
+    """
 
     def __init__(self, ar=1.0, psi=0, alpha=1.67, thetagx=0, thetagy=0,
                  thetarx=0, thetary=0, df=0.02, dt=0.08, dx=0.1,
                  nf=10, nt=80, nx=30, ncuts=5, plot=False, contour=True,
                  figsize=(10, 8), calc_sspec=True, calc_acf=True):
         """
-        Simulate Delay-Doppler Spectrum from Scattered angular spectrum from
-        Yao et al. (2020), modified to get the phase gradient terms correctly
-        and to clean up the bright points in the secondary spectrum which cause
-        artifacts in the ACF
+        Simulate the delay-Doppler spectrum from the scattered angular
+        spectrum, following Yao et al. (2020).
 
-        Here we assume that the angular spectrum interferes with an unscattered
-        wave. The angular spectrum is defined by the spectral exponent. First
-        the ACF of the field is calculated, then it is 2D-FFT'ed to get the
-        brightness distribution. The brightness distribution can be offset by a
-        phase gradient which causes an angular shift as a fraction of the half-
-        width of the brightness distribution.
+        Here we assume that the angular spectrum interferes with an
+        unscattered wave. First the ACF of the electric field is
+        calculated (`calc_brightness`), then it is 2D-FFT'ed to get the
+        brightness distribution. The brightness distribution can be
+        offset by a phase gradient which causes an angular shift as a
+        fraction of the half-width of the brightness distribution.
 
-        The unscattered wave can also be offset by the phase gradient (as it
-        would be in weak scattering), or it can be at zero offset (or anywhere
-        else). The default would be to set the phase gradient angle and the
-        reference angle to be equal
+        The unscattered wave can also be offset by the phase gradient (as
+        it would be in weak scattering), or it can be at zero offset (or
+        anywhere else). The default is to set the phase gradient angle
+        and the reference angle to be equal.
 
-        params:
-            ar: axial ratio
-            alpha: exponent of phase structure function
-            thetagx: scattered wave offset by phase gradient
-            thetagy:
-            thetarx: reference angle for unscattered wave (normally thetax)
-            thetary:
-            dx, nx: spatial resolution and size of e-field ACF, relative to
-                spatial scale
-
+        Parameters
+        ----------
+        ar : float, optional
+            Axial ratio of the anisotropy.
+        psi : float, optional
+            Orientation angle (degrees) of the anisotropy.
+        alpha : float, optional
+            Exponent of the phase structure function (Kolmogorov
+            turbulence would be 5/3; note the default here, 1.67, is used
+            as an approximation of 5/3).
+        thetagx : float, optional
+            Offset (in x) of the scattered wave due to the phase
+            gradient.
+        thetagy : float, optional
+            Offset (in y) of the scattered wave due to the phase
+            gradient.
+        thetarx : float, optional
+            Reference angle (in x) for the unscattered wave (normally
+            equal to `thetagx`).
+        thetary : float, optional
+            Reference angle (in y) for the unscattered wave (normally
+            equal to `thetagy`).
+        df : float, optional
+            Step size in Doppler (frequency-lag-like) coordinate `fd`
+            used when computing the secondary spectrum.
+        dt : float, optional
+            Step size in delay (time-lag-like) coordinate `td` used when
+            computing the secondary spectrum.
+        dx : float, optional
+            Spatial step size of the electric-field ACF grid, relative to
+            the spatial scale.
+        nf : float, optional
+            Half-extent of the Doppler axis `fd`, which runs from ``-nf``
+            to ``+nf`` in steps of `df`.
+        nt : float, optional
+            Half-extent of the delay axis `td`, which runs from ``-nt``
+            to ``+nt`` in steps of `dt`.
+        nx : float, optional
+            Half-extent of the electric-field ACF spatial grid, which
+            runs from ``-nx`` to ``+nx`` in steps of `dx`.
+        ncuts : int, optional
+            Number of Doppler cuts (at different delays) to plot in
+            `plot_cuts`.
+        plot : bool, optional
+            If True, plot the electric-field ACF and brightness
+            distribution after they are computed, and (if `calc_sspec`
+            or `calc_acf` are True) the secondary spectrum, cuts, and/or
+            ACF.
+        contour : bool, optional
+            If True and `plot` and `calc_acf` are True, overlay contours
+            on the ACF plot.
+        figsize : tuple of float, optional
+            Figure size (width, height) in inches, used for all plots
+            made during construction.
+        calc_sspec : bool, optional
+            If True, compute the secondary spectrum (`calc_SS`) after the
+            brightness distribution.
+        calc_acf : bool, optional
+            If True, compute the ACF (`calc_acf`) from the secondary
+            spectrum after it is computed.
         """
 
         self.ar = ar
@@ -836,6 +1283,24 @@ class Brightness():
                 self.plot_acf(figsize=figsize, contour=contour)
 
     def calc_brightness(self):
+        """
+        Compute the angular brightness distribution from the ACF of the
+        electric field.
+
+        First builds the (anisotropic, power-law) ACF of the electric
+        field, `self.acf_efield`, on a grid spanning ``-nx`` to ``+nx`` in
+        steps of `dx` (distances referenced to the spatial scale in the
+        X-direction). The brightness distribution is then obtained by
+        2D Fourier transforming that ACF.
+
+        Returns
+        -------
+        None
+            Sets ``self.x`` (1D spatial axis), ``self.X``, ``self.Y`` (2D
+            coordinate grids), ``self.acf_efield`` (ACF of the electric
+            field), and ``self.B`` (angular brightness distribution) as
+            attributes.
+        """
         # first need to get the brightness distribution from the ACF of the
         # electric field. Reference distances to the spatial scale in the
         # X-direction
@@ -870,32 +1335,46 @@ class Brightness():
 
     def calc_SS(self):
         """
-        now set up the secondary spectrum defined by:
+        Compute the delay-Doppler (secondary) spectrum from the brightness
+        distribution.
 
-        delay = theta^2, i.e. 0.5 L/c = 1
-        doppler = theta, i.e. V/lambda = 1
+        The secondary spectrum is defined with ``delay = theta**2`` (i.e.
+        ``0.5*L/c = 1``) and ``doppler = theta`` (i.e. ``V/lambda = 1``).
+        The differential delay `td` and differential Doppler `fd` are
+        therefore::
 
-        therefore differential delay (td), and differential doppler (fd) are:
-            td = (thetax+thetagx)^2 +(thetay+thetagy)^2 - thetagx^2-thetagy^2
+            td = (thetax+thetagx)**2 + (thetay+thetagy)**2
+                 - thetagx**2 - thetagy**2
             fd = (thetax + thetagx) - thetagx = thetax
-            Jacobian = 1/(thetay+thetagy)
-        thetay + thetagy =
-            sqrt(td - (thetax + thetagx)^2 + thetagx^2 + thetagy^2)
+            Jacobian = 1 / (thetay+thetagy)
+            thetay + thetagy = sqrt(td - (thetax+thetagx)**2
+                                     + thetagx**2 + thetagy**2)
 
-        the arc is defined by (thetay+thetagy) == 0 where there is a half order
-        singularity.
+        Requires `calc_brightness` to have been run first (i.e. `self.X`,
+        `self.Y`, `self.B` to exist).
 
-        The singularity creates a problem in the code because the sampling in
-        fd,td is not synchronized with the arc position, so there can be some
-        very bright points if the sample happens to lie very close to the
-        singularity.
+        Returns
+        -------
+        None
+            Sets ``self.fd``, ``self.td`` (Doppler and delay axes),
+            ``self.thetax``, ``self.thetay`` (angular coordinates
+            corresponding to each `(td, fd)` pair), ``self.jacobian``,
+            ``self.SS`` (secondary spectrum, linear), and ``self.LSS``
+            (secondary spectrum, in dB) as attributes.
 
-        this is not a problem in interpreting the secondary spectrum, but it
-        causes large artifacts when Fourier transforming it to get the ACF.
-
-        So I [Bill Coles, in original Matlab code] have limited the Jacobian by
-        not allowing (thetay+thetagy) to be less than half the step size in
-        thetax and thetay.
+        Notes
+        -----
+        The arc in the secondary spectrum is defined by
+        ``(thetay+thetagy) == 0``, where there is a half-order
+        singularity. This singularity creates a problem in the code
+        because the sampling in `(fd, td)` is not synchronized with the
+        arc position, so there can be very bright points if a sample
+        happens to lie very close to the singularity. This is not a
+        problem for interpreting the secondary spectrum itself, but it
+        causes large artefacts when Fourier transforming it to get the
+        ACF. So (following Bill Coles' original MATLAB code) the Jacobian
+        is limited by not allowing ``(thetay+thetagy)`` to be smaller than
+        half the step size in `thetax`/`thetay` (`self.df`).
         """
 
         fd = np.arange(-self.nf, self.nf, self.df)
@@ -951,6 +1430,18 @@ class Brightness():
         return
 
     def calc_acf(self):
+        """
+        Compute the (normalized) ACF from the secondary spectrum.
+
+        Requires `calc_SS` to have been run first (i.e. `self.SS` to
+        exist).
+
+        Returns
+        -------
+        None
+            Sets ``self.acf`` (2D ACF vs delay and Doppler lag, normalized
+            to a peak of 1) as an attribute.
+        """
         acf = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(self.SS)))
         acf = np.real(acf)
         acf /= np.max(acf)  # normalize acf
@@ -958,6 +1449,17 @@ class Brightness():
         return
 
     def plot_acf_efield(self, figsize=(6, 6)):
+        """
+        Plot the ACF of the electric field vs spatial lag.
+
+        Requires `calc_brightness` to have been run first (i.e.
+        `self.acf_efield` to exist).
+
+        Parameters
+        ----------
+        figsize : tuple of float, optional
+            Figure size (width, height) in inches.
+        """
         plt.figure(figsize=figsize)
         plt.pcolormesh(self.x, self.x, self.acf_efield)
         plt.grid(linewidth=0.2)
@@ -969,6 +1471,17 @@ class Brightness():
         plt.show()
 
     def plot_brightness(self, figsize=(6, 6)):
+        """
+        Plot the angular brightness distribution (in dB).
+
+        Requires `calc_brightness` to have been run first (i.e. `self.B`
+        to exist).
+
+        Parameters
+        ----------
+        figsize : tuple of float, optional
+            Figure size (width, height) in inches.
+        """
         plt.figure(figsize=figsize)
         plt.pcolormesh(self.x, self.x, 10*np.log10(self.B))
         plt.grid(linewidth=0.2)
@@ -980,6 +1493,19 @@ class Brightness():
         plt.show()
 
     def plot_sspec(self, figsize=(6, 6)):
+        """
+        Plot the delay-Doppler (secondary) spectrum, in dB.
+
+        Requires `calc_SS` to have been run first (i.e. `self.fd`,
+        `self.td`, `self.LSS`, `self.SS` to exist). The colour scale is
+        set to 3 dB below the median and maximum of the spectrum (over
+        pixels where ``self.SS > 1e-6``).
+
+        Parameters
+        ----------
+        figsize : tuple of float, optional
+            Figure size (width, height) in inches.
+        """
         plt.figure(figsize=figsize)
         plt.pcolormesh(self.fd, self.td, self.LSS)
         plt.colorbar()
@@ -998,6 +1524,20 @@ class Brightness():
         plt.show()
 
     def plot_acf(self, figsize=(6, 6), contour=True):
+        """
+        Plot the ACF vs delay (frequency) and Doppler (time) lag.
+
+        Requires `calc_acf` to have been run first (i.e. `self.acf` to
+        exist).
+
+        Parameters
+        ----------
+        figsize : tuple of float, optional
+            Figure size (width, height) in inches.
+        contour : bool, optional
+            If True, overlay black contours at ``[0.2, 0.4, 0.6, 0.8]``
+            and a dotted red contour at 0.
+        """
         plt.figure(figsize=figsize)
         plt.pcolormesh(self.fd, self.td, self.acf)
         plt.colorbar()
@@ -1021,13 +1561,24 @@ class Brightness():
 
     def plot_cuts(self, figsize=(6, 6)):
         """
-        plot some cuts. One might want to take some cuts through the ACF. In
-        particular the ACF cut in doppler at zero delay is invarient with phase
-        gradient and is also exp(-(time/t0)^alpha), so you can confirm that
-        the exponent is correct by examining that cut.
+        Plot 1D cuts through the secondary spectrum in Doppler at a
+        selection of delays, and a cut in delay at zero Doppler.
 
-        the cut in frequency (the bandwidth) is very sensitive to ar and its
-        orientation and to phase gradients.
+        One might want to take some cuts through the ACF. In particular,
+        the cut in Doppler at zero delay is invariant with phase gradient
+        and is also ``exp(-(time/t0)**alpha)``, so you can confirm that
+        the exponent is correct by examining that cut. The cut in
+        frequency (the bandwidth) is very sensitive to `ar`, its
+        orientation (`psi`), and to phase gradients.
+
+        Requires `calc_SS` to have been run first (i.e. `self.fd`,
+        `self.td`, `self.LSS`, `self.SS` to exist).
+
+        Parameters
+        ----------
+        figsize : tuple of float, optional
+            Figure size (width, height) in inches, used for each of the
+            two figures produced.
         """
         plt.figure(figsize=figsize)
         nt = len(self.td)

--- a/scintools/scint_utils.py
+++ b/scintools/scint_utils.py
@@ -1025,13 +1025,11 @@ def differential_velocity(params, sun_velocity=220, screen_velocity=220,
     return diff_vel * np.sin(angle), diff_vel * np.cos(angle)
 
 
-def slow_FT(dynspec, freqs):
+def slow_FT(dynspec, freqs, fref=None):
     """
     Slow FT of dynamic spectrum along points of
     t*(f / fref), account for phase scaling of f_D.
     Given a uniform t axis, this reduces to a regular FT
-
-    Reference freq is currently hardcoded to the middle of the band
 
     Parameters
     ----------
@@ -1039,6 +1037,9 @@ def slow_FT(dynspec, freqs):
         Dynamic spectrum to be Fourier Transformed.
     freqs : array_like
         Frequencies of the channels in `dynspec`.
+    fref : float, optional
+        Reference frequency used to scale the time axis. If None
+        (default), the middle of the band is used.
 
     Returns
     -------
@@ -1058,9 +1059,10 @@ def slow_FT(dynspec, freqs):
     # declare the empty result array:
     SS = np.empty((ntime, nfreq), dtype=np.complex128)
 
-    # Reference freq. to middle of band, should change this
-    midf = len(freqs)//2
-    fref = freqs[midf]
+    # Reference freq. defaults to the middle of the band
+    if fref is None:
+        midf = len(freqs)//2
+        fref = freqs[midf]
     fscale = freqs / fref
     fscale = fscale.astype('float64')
 
@@ -1071,7 +1073,7 @@ def slow_FT(dynspec, freqs):
     FTphase = -2j*np.pi*tscale[:, np.newaxis, :] * \
         ft[np.newaxis, :, np.newaxis]
     SS = np.sum(dynspec[:, np.newaxis, :]*np.exp(FTphase), axis=0)
-    SS = np.fft.fftshift(SS, axis=0)
+    SS = np.fft.fftshift(SS, axes=0)
 
     # Still need to FFT y axis, should change to pyfftw for memory and
     #   speed improvement
@@ -1079,6 +1081,37 @@ def slow_FT(dynspec, freqs):
     SS = np.fft.fftshift(SS, axes=1)
 
     return SS
+
+
+def svd_reconstruct(arr, nmodes=1):
+    """
+    Reconstruct a matrix from the leading `nmodes` modes of its
+    singular value decomposition.
+
+    This is the shared SVD core used by `svd_model` (here) and by
+    ``ththmod.svd_model``.
+
+    Parameters
+    ----------
+    arr : array_like
+        Matrix to model with the SVD.
+    nmodes : int, optional
+        Number of leading singular values (modes) to keep; all
+        higher-order modes are zeroed. The default is 1.
+
+    Returns
+    -------
+    model : numpy.ndarray
+        Reconstruction of `arr` using only the leading `nmodes`
+        singular values.
+    """
+
+    u, s, w = np.linalg.svd(arr)
+    s[nmodes:] = 0.0
+    S = np.zeros([len(u), len(w)], np.complex128)
+    S[:len(s), :len(s)] = np.diag(s)
+
+    return np.dot(np.dot(u, S), w)
 
 
 def svd_model(arr, nmodes=1):
@@ -1103,12 +1136,7 @@ def svd_model(arr, nmodes=1):
         singular values.
     """
 
-    u, s, w = np.linalg.svd(arr)
-    s[nmodes:] = 0.0
-    S = np.zeros([len(u), len(w)], np.complex128)
-    S[:len(s), :len(s)] = np.diag(s)
-
-    model = np.dot(np.dot(u, S), w)
+    model = svd_reconstruct(arr, nmodes=nmodes)
     arr = arr / np.abs(model)
 
     return arr, model

--- a/scintools/scint_utils.py
+++ b/scintools/scint_utils.py
@@ -3,7 +3,33 @@
 """
 scint_utils.py
 ----------------------------------
-Useful functions for scintools
+General utility functions used throughout scintools.
+
+This module collects functions that are not specific to any single
+scintools class, including:
+
+- Reading and writing parameter files (``.par``) and scintillation
+  results files (``read_par``, ``pars_to_params``, ``write_results``,
+  ``read_results``, ``read_dynlist``, ``search_and_replace``).
+- Astrophysical/geometric calculations such as barycentric (Roemer)
+  delays, Earth's transverse velocity, binary orbit true anomaly and
+  binary phase, LSR proper motions, and differential ISM/Sun velocity
+  (``get_ssb_delay``, ``get_earth_velocity``, ``make_lsr``,
+  ``get_true_anomaly``, ``get_binphase``, ``differential_velocity``,
+  ``scint_velocity``).
+- Cleaning and creating dynamic spectra from psrchive archives
+  (``clean_archive``, ``make_dynspec``).
+- Array/statistics helpers, e.g. autocorrelation, SVD-based modelling,
+  a slow Fourier transform along scaled axes, NaN interpolation, and
+  simple array utilities (``autocorr``, ``acor``, ``svd_model``,
+  ``slow_FT``, ``interp_nan_2d``, ``cov_to_corr``, ``difference``,
+  ``find_nearest``, ``centres_to_edges``, ``longest_run_of_zeros``,
+  ``is_valid``, ``float_array_from_dict``, ``get_window``).
+- Curvature likelihood/probability calculations used when fitting
+  scintillation arcs (``calculate_curvature_peak_probability``,
+  ``curvature_log_likelihood``, ``save_curvature_data``).
+- Pickling and FITS I/O helpers for large dynamic spectrum objects
+  (``make_pickle``, ``load_pickle``, ``save_fits``).
 """
 
 from __future__ import (absolute_import, division,
@@ -27,7 +53,38 @@ from astropy.coordinates import SkyCoord, get_body_barycentric
 def clean_archive(archive, template=None, bandwagon=0.99, channel_threshold=5,
                   subint_threshold=5, output_directory=None):
     """
-    Cleans an archive using coast_guard
+    Cleans a psrchive archive using the ``coast_guard`` ``surgical`` and
+    ``bandwagon`` cleaners, then unloads the cleaned archive to disk with
+    a ``.clean`` extension.
+
+    Parameters
+    ----------
+    archive : str or psrchive Archive
+        Path to, or already-loaded psrchive archive object, to be
+        cleaned.
+    template : str, optional
+        Path to a template profile. Currently unused by this function,
+        reserved for future use with the cleaners.
+    bandwagon : float, optional
+        ``badchantol`` value passed to the ``coast_guard`` ``bandwagon``
+        cleaner (fraction of subintegrations that must be already
+        flagged bad before a channel is flagged). The default is 0.99.
+    channel_threshold : float, optional
+        ``chanthresh`` value (sigma threshold for flagging channels)
+        passed to the ``surgical`` cleaner. The default is 5.
+    subint_threshold : float, optional
+        ``subintthresh`` value (sigma threshold for flagging
+        subintegrations) passed to the ``surgical`` cleaner. The default
+        is 5.
+    output_directory : str, optional
+        Directory to write the cleaned archive to. If None, the
+        cleaned archive is written alongside the input archive.
+
+    Returns
+    -------
+    None
+        The cleaned archive is written to disk as
+        ``<archive_name>.clean`` in `output_directory`.
     """
 
     # import necessary modules
@@ -66,7 +123,19 @@ def clean_archive(archive, template=None, bandwagon=0.99, channel_threshold=5,
 
 def autocorr(arr):
     """
-    Do a slow calculation of the 2d autocorrelation of an input masked array
+    Do a slow (direct, nested-loop) calculation of the 2D autocorrelation
+    of an input masked array.
+
+    Parameters
+    ----------
+    arr : numpy.ma.MaskedArray
+        2D masked array to autocorrelate.
+
+    Returns
+    -------
+    numpy.ndarray
+        2D autocorrelation of `arr`, with shape twice that of `arr` in
+        each dimension, normalised so the maximum value is 1.
     """
     mean = np.ma.mean(arr)
     std = np.ma.std(arr)
@@ -86,14 +155,35 @@ def autocorr(arr):
 
 def is_valid(array):
     """
-    Returns boolean array of values that are finite an not nan
+    Returns boolean array of values that are finite and not NaN.
+
+    Parameters
+    ----------
+    array : numpy.ndarray
+        Input array.
+
+    Returns
+    -------
+    numpy.ndarray of bool
+        Boolean array, True where `array` is finite and not NaN.
     """
     return np.isfinite(array)*(~np.isnan(array))
 
 
 def read_dynlist(file_path):
     """
-    Reads list of dynamic spectra filenames from path
+    Reads list of dynamic spectra filenames from path.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to a text file containing dynamic spectrum file paths, one
+        per line.
+
+    Returns
+    -------
+    list of str
+        List of dynamic spectrum file paths.
     """
     with open(file_path) as file:
         dynfiles = file.read().splitlines()
@@ -102,7 +192,25 @@ def read_dynlist(file_path):
 
 def write_results(filename, dyn=None):
     """
-    Appends dynamic spectrum information and parameters of interest to file
+    Appends dynamic spectrum information and parameters of interest to
+    file, as a CSV row. Writes a header row first if `filename` is
+    empty or does not yet exist. The set of columns written depends on
+    which scintillation parameter attributes are present on `dyn`
+    (e.g. ``tau``, ``dnu``, ``eta``, ``phasegrad``, etc.).
+
+    Parameters
+    ----------
+    filename : str
+        Path of the CSV file to append to (created if it does not
+        exist).
+    dyn : Dynspec, optional
+        Dynspec object whose attributes (name, mjd, freq, bw, tobs, dt,
+        df, and any fitted scintillation parameters) are written as a
+        row.
+
+    Returns
+    -------
+    None
     """
 
     header = "name,mjd,freq,bw,tobs,dt,df"
@@ -204,7 +312,18 @@ def write_results(filename, dyn=None):
 
 def read_results(filename):
     """
-    Reads a CSV results file written by write_results()
+    Reads a CSV results file written by `write_results`.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the CSV results file to read.
+
+    Returns
+    -------
+    dict
+        Dictionary keyed by column name (from the file's header row),
+        with each value a list of the (string) entries in that column.
     """
 
     csv_data = open(filename, 'r')
@@ -219,6 +338,23 @@ def read_results(filename):
 
 
 def search_and_replace(filename, search, replace):
+    """
+    Reads a text file, replaces all occurrences of one substring with
+    another, and overwrites the file with the result.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the text file to edit in place.
+    search : str
+        Substring to search for.
+    replace : str
+        Substring to substitute in place of `search`.
+
+    Returns
+    -------
+    None
+    """
 
     with open(filename, 'r') as file:
         data = file.read()
@@ -233,7 +369,18 @@ def search_and_replace(filename, search, replace):
 
 def cov_to_corr(cov):
     """
-    Calculate correlation matrix from covariance
+    Calculate correlation matrix from a covariance matrix.
+
+    Parameters
+    ----------
+    cov : numpy.ndarray
+        2D covariance matrix.
+
+    Returns
+    -------
+    numpy.ndarray
+        Correlation matrix corresponding to `cov`. Entries
+        corresponding to zero covariance are set to 0.
     """
     std = np.sqrt(np.diag(cov))
     outer_std = np.outer(std, std)
@@ -244,7 +391,22 @@ def cov_to_corr(cov):
 
 def float_array_from_dict(dictionary, key):
     """
-    Convert an array stored in dictionary to a numpy array
+    Convert an array stored in a dictionary (e.g. as returned by
+    `read_results`) to a numpy float array, treating the string
+    ``'None'`` as NaN.
+
+    Parameters
+    ----------
+    dictionary : dict
+        Dictionary containing the array to convert, keyed by `key`.
+    key : str
+        Key of the array within `dictionary`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Squeezed numpy float array of the values stored at
+        ``dictionary[key]``.
     """
     ind = np.argwhere(np.array(dictionary[key]) == 'None').ravel()
 
@@ -258,6 +420,24 @@ def float_array_from_dict(dictionary, key):
 
 
 def save_fits(filename, dyn):
+    """
+    Saves a dynamic spectrum to a FITS file as the primary HDU.
+
+    Parameters
+    ----------
+    filename : str
+        Path of the FITS file to write. Raises an error if the file
+        already exists.
+    dyn : Dynspec
+        Dynspec object whose ``dyn`` attribute (2D dynamic spectrum
+        array) is written to the FITS file, transposed and flipped so
+        that frequency runs along the first axis in the expected FITS
+        orientation.
+
+    Returns
+    -------
+    None
+    """
 
     from astropy.io import fits
 
@@ -269,8 +449,20 @@ def save_fits(filename, dyn):
 
 def difference(x):
     """
-    unlike np.diff, computes differences between centres of elements in x,
-        returns numpy array same size as x
+    Unlike `numpy.diff`, computes differences between the centres of
+    neighbouring elements in `x`, returning an array the same size as
+    `x`. For interior points this is ``(x[i+1] - x[i-1]) / 2``; at the
+    edges it is the one-sided half-difference.
+
+    Parameters
+    ----------
+    x : array_like
+        Input 1D array.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of centred differences, the same length as `x`.
     """
     dx = []
     for i in range(0, len(x)):
@@ -285,8 +477,27 @@ def difference(x):
 
 def get_ssb_delay(mjds, raj, decj, message=True):
     """
-    Get Romer delay to Solar System Barycentre (SSB) for correction of site
-    arrival times to barycentric.
+    Get Romer delay to Solar System Barycentre (SSB) for correction of
+    site arrival times to barycentric.
+
+    Parameters
+    ----------
+    mjds : array_like
+        Modified Julian Dates to calculate the delay for.
+    raj : str
+        Right ascension (J2000) of the pulsar, in hourangle-parsable
+        string format (e.g. ``'hh:mm:ss'``).
+    decj : str
+        Declination (J2000) of the pulsar, in degree-parsable string
+        format (e.g. ``'dd:mm:ss'``).
+    message : bool, optional
+        If True (default), print a reminder that the returned delays
+        should be added to the site arrival times.
+
+    Returns
+    -------
+    numpy.ndarray
+        Romer delays to the SSB, in seconds, one per input MJD.
     """
 
     from astropy.constants import au, c
@@ -312,6 +523,35 @@ def get_ssb_delay(mjds, raj, decj, message=True):
 
 
 def make_lsr(d, raj, decj, pmra, pmdec, vr=0):
+    """
+    Converts a pulsar's barycentric proper motion and radial velocity to
+    proper motion in the Local Standard of Rest (LSR) frame, using the
+    IAU standard solar motion (11.1, 12.24, 7.25 km/s) with respect to
+    the LSR.
+
+    Parameters
+    ----------
+    d : float
+        Distance to the pulsar, in kpc.
+    raj : str
+        Right ascension (J2000) of the pulsar, in hourangle-parsable
+        string format (e.g. ``'hh:mm:ss'``).
+    decj : str
+        Declination (J2000) of the pulsar, in degree-parsable string
+        format (e.g. ``'dd:mm:ss'``).
+    pmra : float
+        Proper motion in right ascension (``pm_ra_cosdec``), in mas/yr.
+    pmdec : float
+        Proper motion in declination, in mas/yr.
+    vr : float, optional
+        Radial velocity, in km/s. The default is 0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Proper motion components (RA, Dec) of the pulsar in the LSR
+        frame, in mas/yr.
+    """
     from astropy.coordinates import BarycentricTrueEcliptic, LSR, SkyCoord
     from astropy import units as u
 
@@ -348,8 +588,33 @@ def make_lsr(d, raj, decj, pmra, pmdec, vr=0):
 
 def get_earth_velocity(mjds, raj, decj, radial=False):
     """
-    Calculates the component of Earth's velocity transverse to the line of
-    sight, in RA and DEC. Optionally returns the radial velocity
+    Calculates the component of Earth's velocity transverse to the line
+    of sight, in RA and Dec. Optionally also returns the radial
+    velocity component.
+
+    Parameters
+    ----------
+    mjds : array_like
+        Modified Julian Dates to calculate the velocity for.
+    raj : str
+        Right ascension (J2000) of the pulsar, in hourangle-parsable
+        string format (e.g. ``'hh:mm:ss'``).
+    decj : str
+        Declination (J2000) of the pulsar, in degree-parsable string
+        format (e.g. ``'dd:mm:ss'``).
+    radial : bool, optional
+        If True, also return the radial (line-of-sight) component of
+        Earth's velocity. The default is False.
+
+    Returns
+    -------
+    vearth_ra : numpy.ndarray
+        Earth's velocity component in the RA direction, in km/s.
+    vearth_dec : numpy.ndarray
+        Earth's velocity component in the Dec direction, in km/s.
+    vearth_radial : numpy.ndarray, optional
+        Earth's radial velocity component, in km/s. Only returned if
+        `radial` is True.
     """
 
     from astropy.time import Time
@@ -397,7 +662,23 @@ def get_earth_velocity(mjds, raj, decj, radial=False):
 
 def read_par(parfile):
     """
-    Reads a par file and return a dictionary of parameter names and values
+    Reads a pulsar parameter (``.par``) file and returns a dictionary of
+    parameter names and values. Certain timing-model-only parameters
+    (e.g. ``DMMODEL``, ``JUMP``, ``TZRMJD``) are ignored. For each
+    numeric parameter, an associated ``<PARAM>_TYPE`` entry is added
+    (``'d'`` for int, ``'f'``/``'e'`` for float, ``'s'`` for string),
+    and if an uncertainty is present, a ``<PARAM>_ERR`` entry is added.
+
+    Parameters
+    ----------
+    parfile : str
+        Path to the parameter file to read.
+
+    Returns
+    -------
+    dict
+        Dictionary of parameter names and values (plus associated
+        ``_ERR`` and ``_TYPE`` entries where applicable).
     """
 
     par = {}
@@ -452,7 +733,18 @@ def read_par(parfile):
 
 def mjd_to_year(mjd):
     """
-    converts mjd to year
+    Converts Modified Julian Date(s) to a Besselian/decimal year.
+
+    Parameters
+    ----------
+    mjd : float or array_like
+        Modified Julian Date(s) to convert.
+
+    Returns
+    -------
+    float or numpy.ndarray
+        Decimal year(s) (``astropy.time.Time.byear``) corresponding to
+        `mjd`.
     """
     t = Time(mjd, format='mjd')
     yrs = t.byear  # observation year
@@ -461,7 +753,20 @@ def mjd_to_year(mjd):
 
 def find_nearest(arr, val):
     """
-    Returns the index of an array (arr) that is nearest to value (val)
+    Returns the index of an array (`arr`) that is nearest to value
+    (`val`).
+
+    Parameters
+    ----------
+    arr : array_like
+        Array to search.
+    val : float
+        Value to find the nearest element to.
+
+    Returns
+    -------
+    int
+        Index of the element of `arr` closest to `val`.
     """
     arr = np.asarray(arr)
     ind = np.argmin(np.abs(arr - val))
@@ -469,6 +774,21 @@ def find_nearest(arr, val):
 
 
 def longest_run_of_zeros(arr):
+    """
+    Finds the length of the longest run of consecutive zeros in an
+    array.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input 1D array (or iterable) of numbers.
+
+    Returns
+    -------
+    int
+        Length of the longest consecutive run of zero-valued elements
+        in `arr`.
+    """
     count = 0
     max_count = 0
     for num in arr:
@@ -479,10 +799,24 @@ def longest_run_of_zeros(arr):
 
 def pars_to_params(pars, params=None):
     """
-    Converts a dictionary of par file parameters from read_par() to an
-    lmfit Parameters() class to use in models
+    Converts a dictionary of par file parameters from `read_par` to an
+    ``lmfit`` ``Parameters()`` object to use in models. Right ascension
+    and declination (``RAJ``/``RA`` and ``DECJ``) are converted from
+    sexagesimal strings to radians. By default, parameters are not
+    varied (``vary=False``); string-valued parameters are skipped.
 
-    By default, parameters are not varied
+    Parameters
+    ----------
+    pars : dict
+        Dictionary of parameters, as returned by `read_par`.
+    params : lmfit.Parameters, optional
+        Existing ``lmfit`` ``Parameters()`` object to append parameters
+        to. If None (default), a new object is created.
+
+    Returns
+    -------
+    lmfit.Parameters
+        ``Parameters()`` object with entries added from `pars`.
     """
 
     from lmfit import Parameters
@@ -508,8 +842,29 @@ def pars_to_params(pars, params=None):
 
 def get_true_anomaly(mjds, pars):
     """
-    Calculates true anomalies for an array of barycentric MJDs and a parameter
-    dictionary
+    Calculates true anomalies for an array of barycentric MJDs and a
+    parameter dictionary. Supports either an ``ELL1``-style binary
+    model (using ``TASC``, ``EPS1``, ``EPS2``) or a standard Keplerian
+    model (using ``T0``, ``ECC``). For near-circular orbits (``ECC`` <
+    1e-4), the eccentric anomaly is approximated by the mean anomaly;
+    otherwise Kepler's equation is solved numerically.
+
+    Parameters
+    ----------
+    mjds : array_like
+        Barycentric Modified Julian Dates to calculate the true anomaly
+        for.
+    pars : dict
+        Parameter dictionary containing the orbital eccentricity
+        (``ECC``, or ``EPS1``/``EPS2`` for ``ELL1``), binary period
+        (``PB``, days), reference epoch (``T0`` or ``TASC``, MJD), and
+        optionally the binary period derivative (``PBDOT``).
+
+    Returns
+    -------
+    numpy.ndarray or float
+        True anomaly (or anomalies), in radians, in the range
+        [0, 2*pi).
     """
 
     if 'TASC' in pars.keys():
@@ -556,8 +911,26 @@ def get_true_anomaly(mjds, pars):
 
 def get_binphase(mjds, pars):
     """
-    Calculates binary phase for an array of barycentric MJDs and a parameter
-    dictionary
+    Calculates binary phase (true anomaly plus argument of periastron)
+    for an array of barycentric MJDs and a parameter dictionary. For
+    ``ELL1``-style binary models (parameter dictionary contains
+    ``TASC``), the argument of periastron is taken to be zero.
+
+    Parameters
+    ----------
+    mjds : array_like
+        Barycentric Modified Julian Dates to calculate the binary phase
+        for.
+    pars : dict
+        Parameter dictionary as used by `get_true_anomaly`, plus
+        (for non-``ELL1`` models) the argument of periastron ``OM``
+        (degrees) and optionally its time derivative ``OMDOT``
+        (deg/yr).
+
+    Returns
+    -------
+    numpy.ndarray or float
+        Binary phase, in radians.
     """
     U = get_true_anomaly(mjds, pars)
 
@@ -662,11 +1035,17 @@ def slow_FT(dynspec, freqs):
 
     Parameters
     ----------
+    dynspec : ndarray, shape (ntime, nfreq)
+        Dynamic spectrum to be Fourier Transformed.
+    freqs : array_like
+        Frequencies of the channels in `dynspec`.
 
-    dynspec: [time, frequency] ndarray
-        Dynamic spectrum to be Fourier Transformed
-    f: array of floats
-        Frequencies of the channels in dynspec
+    Returns
+    -------
+    numpy.ndarray, shape (ntime, nfreq), complex
+        Secondary spectrum: `dynspec` Fourier Transformed along the
+        scaled time axis and then along frequency, with both axes
+        fftshifted.
     """
 
     # cast dynspec as float 64
@@ -709,13 +1088,19 @@ def svd_model(arr, nmodes=1):
     Parameters
     ----------
     arr : array_like
-      Time/freq visiblity matrix
-    nmodes :
+        Time/freq visibility matrix.
+    nmodes : int, optional
+        Number of leading singular values (modes) to keep when
+        constructing the model; all higher-order modes are zeroed.
+        The default is 1.
 
     Returns
     -------
-    Original data array multiplied by the largest SVD mode conjugate,
-    and the model
+    arr : numpy.ndarray
+        Input array divided by the absolute value of the SVD `model`.
+    model : numpy.ndarray
+        Reconstruction of `arr` using only the leading `nmodes`
+        singular values.
     """
 
     u, s, w = np.linalg.svd(arr)
@@ -731,7 +1116,42 @@ def svd_model(arr, nmodes=1):
 
 def scint_velocity(params, dnu, tau, freq, dnuerr=None, tauerr=None, a=2.53e4):
     """
-    Calculate scintillation velocity from ACF frequency and time scales
+    Calculate the scintillation velocity (:math:`V_{ISS}`) from the ACF
+    scintillation bandwidth and timescale, using the thin-screen
+    scintillation velocity equation. If `params` is provided, the
+    thin-screen coefficient is scaled by the pulsar distance ``d`` and
+    the screen fractional distance ``s``; otherwise a fixed coefficient
+    `a` is used (e.g. for fitting).
+
+    Parameters
+    ----------
+    params : dict or lmfit.Parameters or None
+        Parameters containing the pulsar distance ``d`` (and its
+        uncertainty ``derr``/``d.stderr``) and screen fractional
+        distance ``s`` (and its uncertainty ``serr``/``s.stderr``). If
+        None, `a` is used directly as the thin-screen coefficient.
+    dnu : float or array_like
+        Scintillation bandwidth, in MHz.
+    tau : float or array_like
+        Scintillation timescale, in seconds.
+    freq : float or array_like
+        Observing frequency, in MHz.
+    dnuerr : float or array_like, optional
+        Uncertainty on `dnu`. If provided along with `tauerr`, the
+        uncertainty on the scintillation velocity is also returned.
+    tauerr : float or array_like, optional
+        Uncertainty on `tau`.
+    a : float, optional
+        Fixed thin-screen coefficient to use when `params` is None.
+        The default is 2.53e4.
+
+    Returns
+    -------
+    viss : float or numpy.ndarray
+        Scintillation velocity, in km/s.
+    viss_err : float or numpy.ndarray, optional
+        Uncertainty on `viss`. Only returned if both `dnuerr` and
+        `tauerr` are provided.
     """
 
     freq = freq / 1e3   # convert to GHz
@@ -768,7 +1188,23 @@ def scint_velocity(params, dnu, tau, freq, dnuerr=None, tauerr=None, a=2.53e4):
 
 def interp_nan_2d(array, method='linear'):
     """
-    Fill in NaN values of a 2D array using linear interpolation
+    Fill in NaN (and other invalid) values of a 2D array by
+    interpolating from the surrounding valid pixels.
+
+    Parameters
+    ----------
+    array : array_like
+        2D input array possibly containing NaN or otherwise invalid
+        values.
+    method : str, optional
+        Interpolation method passed to `scipy.interpolate.griddata`
+        (one of ``'linear'``, ``'nearest'``, ``'cubic'``). The default
+        is ``'linear'``.
+
+    Returns
+    -------
+    numpy.ndarray
+        2D array with invalid values filled in by interpolation.
     """
     array = np.array(array).squeeze()
     x = np.arange(0, array.shape[1])
@@ -786,8 +1222,18 @@ def interp_nan_2d(array, method='linear'):
 
 def centres_to_edges(arr):
     """
-    Take an array of pixel-centres, and return an array of pixel-edges
-        assumes the pixel-centres are evenly spaced
+    Take an array of pixel-centres, and return an array of pixel-edges.
+    Assumes the pixel-centres are evenly spaced.
+
+    Parameters
+    ----------
+    arr : array_like
+        1D array of evenly-spaced pixel-centre values.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of pixel-edge values, one longer than `arr`.
     """
     darr = np.abs(arr[1] - arr[0])
     arr_edges = arr - darr/2
@@ -796,7 +1242,19 @@ def centres_to_edges(arr):
 
 def make_pickle(obj, filepath):
     """
-    pickle.write, which works for very large files
+    Pickle `obj` to `filepath`, writing in chunks so that this also
+    works for objects whose pickled representation is larger than 2GB.
+
+    Parameters
+    ----------
+    obj : object
+        Python object to pickle (e.g. a Dynspec object).
+    filepath : str
+        Path of the file to write the pickle to.
+
+    Returns
+    -------
+    None
     """
     max_bytes = 2**31 - 1
     bytes_out = pickle.dumps(obj)
@@ -809,7 +1267,32 @@ def make_pickle(obj, filepath):
 
 def get_window(nt, nf, window='hanning', frac=0.1):
     """
-    Returns a window to apply before computing an FFT
+    Returns tapering windows to apply along the time and frequency axes
+    before computing an FFT. Each window is a standard numpy taper
+    (e.g. Hanning) covering a fraction `frac` of the axis length,
+    padded with ones in the middle so the returned window matches the
+    full axis length.
+
+    Parameters
+    ----------
+    nt : int
+        Length of the time axis.
+    nf : int
+        Length of the frequency axis.
+    window : str, optional
+        Window type: one of ``'hanning'``, ``'hamming'``,
+        ``'blackman'``, or ``'bartlett'``. The default is
+        ``'hanning'``.
+    frac : float, optional
+        Fraction of each axis length to taper at the edges (via the
+        selected window function). The default is 0.1.
+
+    Returns
+    -------
+    chan_window : numpy.ndarray
+        Tapering window of length `nt`, for the time axis.
+    subint_window : numpy.ndarray
+        Tapering window of length `nf`, for the frequency axis.
     """
     if window.lower() == 'hanning':
         cw = np.hanning(np.floor(frac*nt))
@@ -835,7 +1318,34 @@ def get_window(nt, nf, window='hanning', frac=0.1):
 def calculate_curvature_peak_probability(power_data, noise_level, smooth=True,
                                          curvatures=None, log=False):
     """
-    Calculates the probability distribution
+    Calculates the (unnormalised) Gaussian probability distribution of
+    the arc curvature "power vs curvature" profile, modelling the
+    profile as a Gaussian peak at its maximum with standard deviation
+    given by `noise_level`.
+
+    Parameters
+    ----------
+    power_data : array_like
+        Power (Doppler profile) as a function of curvature, for one or
+        more observations.
+    noise_level : float or array_like
+        Noise standard deviation of `power_data`, used as the Gaussian
+        width. If `smooth` is True, also used as the Gaussian smoothing
+        sigma.
+    smooth : bool, optional
+        If True (default), smooth `power_data` with a Gaussian filter
+        of sigma `noise_level` before computing the probability.
+    curvatures : array_like, optional
+        Curvature values corresponding to `power_data`. Currently
+        unused (normalisation by `curvatures` is not yet implemented).
+    log : bool, optional
+        If True, return the log-probability instead of the probability.
+        The default is False.
+
+    Returns
+    -------
+    numpy.ndarray
+        (Log-)probability distribution, same shape as `power_data`.
     """
     if smooth:
         power_data = gaussian_filter1d(power_data, noise_level)
@@ -856,7 +1366,28 @@ def calculate_curvature_peak_probability(power_data, noise_level, smooth=True,
 
 def save_curvature_data(dyn, filename=None):
     """
-    Saves the "power vs curvature" and noise level to file
+    Saves the "power vs curvature" arc-fitting data and noise level to
+    a ``.npz`` file, for later use with
+    `calculate_curvature_peak_probability` or
+    `curvature_log_likelihood`. The exact arrays saved depend on which
+    attributes are present on `dyn` (single or double sideband,
+    normalised secondary spectrum averaging method).
+
+    Parameters
+    ----------
+    dyn : Dynspec
+        Dynspec object with arc-curvature fitting results (e.g.
+        ``eta_array``, ``norm_sspec_avg`` or ``norm_sspec_avg1``/
+        ``norm_sspec_avg2`` or ``normsspec_fdop``/``normsspecavg``, and
+        ``noise``).
+    filename : str, optional
+        Output file path (passed to `numpy.savez`, ``.npz`` is
+        appended automatically). If None, defaults to
+        ``dyn.name + 'curvature_data'``.
+
+    Returns
+    -------
+    None
     """
     if filename is None:
         filename = dyn.name + 'curvature_data'
@@ -877,7 +1408,19 @@ def save_curvature_data(dyn, filename=None):
 
 def load_pickle(filepath):
     """
-    pickle.load, which works for very large files
+    Load a pickled object from `filepath`, reading in chunks so that
+    this also works for pickle files larger than 2GB. Counterpart to
+    `make_pickle`.
+
+    Parameters
+    ----------
+    filepath : str
+        Path of the pickle file to read.
+
+    Returns
+    -------
+    object
+        The unpickled Python object.
     """
     max_bytes = 2**31 - 1
     input_size = os.path.getsize(filepath)
@@ -893,8 +1436,29 @@ def load_pickle(filepath):
 
 def make_dynspec(archive, template=None, phasebin=1):
     """
-    Creates a psrflux-format dynamic spectrum from an archive
-        $ psrflux -s [template] -e dynspec [archive]
+    Creates a ``psrflux``-format dynamic spectrum from an archive,
+    equivalent to running ``psrflux -s [template] -e dynspec
+    [archive]``.
+
+    Notes
+    -----
+    This function is a placeholder for future functionality and is
+    not yet implemented.
+
+    Parameters
+    ----------
+    archive : str or psrchive Archive
+        Path to, or already-loaded psrchive archive object, to create
+        the dynamic spectrum from.
+    template : str, optional
+        Path to a template profile, passed to ``psrflux -s``.
+    phasebin : int, optional
+        Number of pulse phase bins to integrate over when forming the
+        dynamic spectrum. The default is 1.
+
+    Returns
+    -------
+    None
     """
     return
 

--- a/scintools/scint_utils.py
+++ b/scintools/scint_utils.py
@@ -895,7 +895,7 @@ def get_true_anomaly(mjds, pars):
         E = []
         for m in M:
             E.append(fsolve(lambda E: E - ECC*np.sin(E) - m, m))
-        E = np.asarray(E, dtype=np.float128)
+        E = np.asarray(E, dtype=np.longdouble)
 
     # true anomaly
     U = 2*np.arctan2(np.sqrt(1 + ECC) * np.sin(E/2),

--- a/scintools/ththmod.py
+++ b/scintools/ththmod.py
@@ -3,6 +3,46 @@
 """
 ththmod.py
 ----------------------------------
+Tools for the Theta-Theta ("theta-theta") transform used to measure
+scintillation arc curvatures and to perform phase retrieval on pulsar
+dynamic spectra.
+
+For a one dimensional line of scattered images at a fixed distance, the
+conjugate wavefield forms a parabola in Doppler shift/time delay
+(``fD``/``tau``) space, and the conjugate (secondary) spectrum -- the
+self-convolution of that wavefield -- shows the familiar scintillation
+arcs and inverted arclets. Reparameterizing each point of the conjugate
+spectrum by the Doppler shifts (``theta1``, ``theta2``) of the pair of
+images that interfere to produce it maps the arcs and arclets onto
+straight lines in "theta-theta" space; when the assumed arc curvature
+(``eta``) matches the data these lines become parallel to the axes,
+which enables both curvature measurement (by eigenvalue/singular-value
+or chi-squared search) and phase retrieval (by eigen-decomposition of
+the theta-theta matrix). See Sprenger et al. 2021, MNRAS, 500, 1114 and
+docs/source/thetatheta.rst for the scientific background.
+
+Core building blocks
+---------------------
+`fft_axis` : Build the Fourier-conjugate axis (e.g. Doppler frequency
+    from time, or time delay from frequency) for a data axis carrying
+    astropy units.
+`thth_map`, `thth_redmap` : Map a conjugate/secondary spectrum into
+    theta-theta space for a given arc curvature and set of bin edges
+    (``thth_redmap`` returns the largest sub-square fully covered by the
+    data).
+`rev_map` : Inverse-map a theta-theta array back into conjugate
+    spectrum space.
+`min_edges`, `arc_edges` : Compute theta-theta bin edges.
+`modeler`, `chisq_calc`, `Eval_calc`, `singularvalue_calc` : Build
+    models and search statistics used to find the best-fit curvature.
+`single_search`, `single_search_thin`, `calc_asymmetry`,
+`VLBI_chunk_retrieval`, `single_chunk_retrieval` : Higher level drivers
+    for curvature searches and phase retrieval on chunks of data,
+    designed for use with MPI4py-style parallel processing.
+`mosaic`, `rotMos`, `rotInit`, `rotFit`, `rotDer`, `fullMos*` : Combine
+    (mosaic) phase-retrieved wavefield chunks into a single composite
+    wavefield.
+
 Code for handling theta-theta transformation by Daniel Baker
 """
 
@@ -496,6 +536,44 @@ def fft_axis(x, unit, pad=0):
 def singularvalue_calc(
     CS, tau, fd, eta, edges, etaArclet, edgesArclet, centerCut
 ):
+    """
+    Calculate the largest singular value of the theta-theta matrix built
+    from a Conjugate/Secondary Spectrum using two possibly different
+    curvatures for the two theta axes (main arc for theta1, inverted
+    arclets for theta2), after zeroing out a central strip in theta1.
+
+    This is an alternative to `Eval_calc` for curvature searches: instead
+    of the largest eigenvalue of a Hermitian theta-theta matrix it uses
+    the largest singular value of `two_curve_map`'s (generally
+    non-Hermitian) result, which also allows arclets with a different
+    curvature than the main arc to be excised via `centerCut`.
+
+    Parameters
+    ----------
+    CS : `~numpy.ndarray`
+        Conjugate Spectrum (or its power, e.g. the secondary spectrum).
+    tau : `~astropy.units.Quantity`
+        Time delay coordinates for the CS (us).
+    fd : `~astropy.units.Quantity`
+        Doppler shift coordinates for the CS (mHz).
+    eta : `~astropy.units.Quantity`
+        Arc curvature used for theta1, the main arc (s**3).
+    edges : `~astropy.units.Quantity`
+        Bin edges in theta1 for theta-theta mapping (mHz).
+    etaArclet : `~astropy.units.Quantity`
+        Arc curvature used for theta2, the inverted arclets (s**3).
+    edgesArclet : `~astropy.units.Quantity`
+        Bin edges in theta2 for theta-theta mapping (mHz).
+    centerCut : `~astropy.units.Quantity`
+        Points with ``|theta1| < centerCut`` are set to zero before the
+        singular value decomposition, to remove contamination from
+        (e.g.) the zero-delay/zero-Doppler feature (mHz).
+
+    Returns
+    -------
+    S0 : float
+        The largest singular value of the masked theta-theta matrix.
+    """
     tau = unit_checks(tau, "tau", u.us)
     fd = unit_checks(fd, "fd", u.mHz)
     eta = unit_checks(eta, "eta", u.s**3)
@@ -2366,6 +2444,31 @@ def errString(fit, sig):
 
 
 def errCalc(etas, eigs, fitPars):
+    """
+    Estimate the standard error on the fitted curvature (the vertex, x0,
+    of a parabola fit to an eigenvalue- or chi-squared-vs-curvature
+    curve), propagated from the scatter of the data about the best-fit
+    parabola `chi_par`. This provides an alternative to the uncertainty
+    obtained from the covariance matrix returned by
+    `~scipy.optimize.curve_fit`.
+
+    Parameters
+    ----------
+    etas : `~numpy.ndarray` or `~astropy.units.Quantity`
+        Curvatures at which `eigs` was measured (the independent
+        variable of the `chi_par` fit).
+    eigs : `~numpy.ndarray`
+        Measured values (e.g. largest eigenvalue or chi-squared) at each
+        curvature in `etas`.
+    fitPars : tuple or `~numpy.ndarray`
+        Best-fit parameters ``(A, x0, C)`` of `chi_par` fit to
+        ``(etas, eigs)``.
+
+    Returns
+    -------
+    x0Err : float
+        Estimated standard error on the fitted curvature x0.
+    """
     M = chi_par(etas.value, *fitPars)
     sigEstimate = np.std(eigs - M)
     x0Err = (

--- a/scintools/ththmod.py
+++ b/scintools/ththmod.py
@@ -54,11 +54,16 @@ from matplotlib.colors import LogNorm, SymLogNorm
 from scipy.optimize import curve_fit
 import warnings
 
+from scintools.scint_utils import svd_reconstruct
+
 
 def svd_model(arr, nmodes=1):
     """
     Model a matrix using the first nmodes modes of the singular value
     decomposition
+
+    Thin wrapper around `scintools.scint_utils.svd_reconstruct`, the
+    shared SVD core, so the reconstruction logic lives in one place.
 
     Parameters
     ----------
@@ -67,12 +72,7 @@ def svd_model(arr, nmodes=1):
     nmodes: int, optional
         Number of modes used in the SVD model. Defaults to 1
     """
-    u, s, w = np.linalg.svd(arr)
-    s[nmodes:] = 0
-    S = np.zeros(([len(u), len(w)]), np.complex128)
-    S[: len(s), : len(s)] = np.diag(s)
-    model = np.dot(np.dot(u, S), w)
-    return model
+    return svd_reconstruct(arr, nmodes=nmodes)
 
 
 def chi_par(x, A, x0, C):
@@ -1567,6 +1567,55 @@ def mask_func(w):
     return np.sin((np.pi / 2) * x / w) ** 2
 
 
+def chunk_mask(shape, cf, ct, ncf, nct, cwf, cwt):
+    """
+    Build the overlap-weighting mask for a single mosaic chunk.
+
+    Chunks are weighted higher towards their centre and cross-faded with
+    their neighbours over the overlapping half in each direction, so that
+    stacked chunks add smoothly. This is the shared implementation used by
+    `mosaic`, `rotMos`, `rotInit`, `rotDer`, `fullMos`, `fullMosGrad` and
+    `fullMosHess`.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Shape of the chunk (freq within chunk, time within chunk).
+    cf, ct : int
+        Frequency and time index of the chunk being weighted.
+    ncf, nct : int
+        Total number of chunks in frequency and time.
+    cwf, cwt : int
+        Chunk width in frequency and time.
+
+    Returns
+    -------
+    numpy.ndarray
+        Weighting mask with the same shape as the chunk.
+    """
+    mask = np.ones(shape)
+
+    # Determine Mask for new chunk (chunks will have higher weights
+    #     towards their centre)
+    if cf > 0:
+        # All chunks but the first in frequency overlap for the first
+        #     half in frequency
+        mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
+    if cf < ncf - 1:
+        # All chunks but the last in frequency overlap for the second
+        #     half in frequency
+        mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
+    if ct > 0:
+        # All chunks but the first in time overlap for the first half
+        #     in time
+        mask[:, : cwt // 2] *= mask_func(cwt // 2)
+    if ct < nct - 1:
+        # All chunks but the last in time overlap for the second half
+        #     in time
+        mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+    return mask
+
+
 def mosaic(chunks):
     """Combine recovered wavefield chunks into a single composite wavefield by
     correcting for random phase rotation and stacking
@@ -1600,26 +1649,7 @@ def mosaic(chunks):
                 cf * cwf // 2: cf * cwf // 2 + cwf,
                 ct * cwt // 2: ct * cwt // 2 + cwt,
             ]
-            mask = np.ones(chunk_new.shape)
-
-            # Determine Mask for new chunk (chunks will have higher weights
-            #     towards their centre)
-            if cf > 0:
-                # All chunks but the first in frequency overlap for the first
-                #     half in frequency
-                mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-            if cf < ncf - 1:
-                # All chunks but the last in frequency overlap for the second
-                #     half in frequency
-                mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
-            if ct > 0:
-                # All chunks but the first in time overlap for the first half
-                #     in time
-                mask[:, : cwt // 2] *= mask_func(cwt // 2)
-            if ct < nct - 1:
-                # All chunks but the last in time overlap for the second half
-                #     in time
-                mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+            mask = chunk_mask(chunk_new.shape, cf, ct, ncf, nct, cwf, cwt)
             # Average phase difference between new chunk and existing wavefield
             rot = np.angle((chunk_old * np.conjugate(chunk_new) * mask).mean())
             # Add masked and roated new chunk to wavefield
@@ -1815,26 +1845,7 @@ def rotMos(chunks, x):
             chunk_new = np.copy(chunks[cf, ct, :, :])
 
             # Find overlap with current wavefield
-            mask = np.ones(chunk_new.shape)
-
-            # Determine Mask for new chunk (chunks will have higher weights
-            #     towards their centre)
-            if cf > 0:
-                # All chunks but the first in frequency overlap for the first
-                #     half in frequency
-                mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-            if cf < ncf - 1:
-                # All chunks but the last in frequency overlap for the second
-                #     half in frequency
-                mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
-            if ct > 0:
-                # All chunks but the first in time overlap for the first half
-                #     in time
-                mask[:, : cwt // 2] *= mask_func(cwt // 2)
-            if ct < nct - 1:
-                # All chunks but the last in time overlap for the second half
-                #     in time
-                mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+            mask = chunk_mask(chunk_new.shape, cf, ct, ncf, nct, cwf, cwt)
             rot = 0
             if cf > 0 or ct > 0:
                 rot = x[nct * cf + ct - 1]
@@ -1900,26 +1911,7 @@ def rotInit(chunks):
                 cf * cwf // 2: cf * cwf // 2 + cwf,
                 ct * cwt // 2: ct * cwt // 2 + cwt,
             ]
-            mask = np.ones(chunk_new.shape)
-
-            # Determine Mask for new chunk (chunks will have higher weights
-            #     towards their centre)
-            if cf > 0:
-                # All chunks but the first in frequency overlap for the first
-                #     half in frequency
-                mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-            if cf < ncf - 1:
-                # All chunks but the last in frequency overlap for the second
-                #     half in frequency
-                mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
-            if ct > 0:
-                # All chunks but the first in time overlap for the first half
-                #     in time
-                mask[:, : cwt // 2] *= mask_func(cwt // 2)
-            if ct < nct - 1:
-                # All chunks but the last in time overlap for the second half
-                #     in time
-                mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+            mask = chunk_mask(chunk_new.shape, cf, ct, ncf, nct, cwf, cwt)
             # Average phase difference between new chunk and existing wavefield
             rot = np.angle((chunk_old * np.conjugate(chunk_new) * mask).mean())
             # Add masked and roated new chunk to wavefield
@@ -1966,28 +1958,7 @@ def rotDer(x, chunks):
                         ct * cwt // 2: ct * cwt // 2 + cwt,
                     ]
                 )
-                mask = np.ones(y.shape)
-
-                # Determine Mask for new chunk (chunks will have higher weights
-                #     towards their centre)
-                if cf > 0:
-                    # All chunks but the first in frequency overlap for the
-                    #     first half in frequency
-                    mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-                if cf < ncf - 1:
-                    # All chunks but the last in frequency overlap for the
-                    #     second half in frequency
-                    mask[cwf // 2:, :] *= (
-                        1 - mask_func(cwf // 2)[:, np.newaxis]
-                    )
-                if ct > 0:
-                    # All chunks but the first in time overlap for the first
-                    #     half in time
-                    mask[:, : cwt // 2] *= mask_func(cwt // 2)
-                if ct < nct - 1:
-                    # All chunks but the last in time overlap for the second
-                    #     half in time
-                    mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+                mask = chunk_mask(y.shape, cf, ct, ncf, nct, cwf, cwt)
                 y *= mask
                 rot = x[nct * cf + ct - 1]
                 xx -= y * np.exp(1j * rot)
@@ -2030,26 +2001,7 @@ def fullMos(chunks, p):
             chunk_new = np.copy(chunks[cf, ct, :, :])
 
             # Find overlap with current wavefield
-            mask = np.ones(chunk_new.shape)
-
-            # Determine Mask for new chunk (chunks will have higher weights
-            #     towards their centre)
-            if cf > 0:
-                # All chunks but the first in frequency overlap for the first
-                #     half in frequency
-                mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-            if cf < ncf - 1:
-                # All chunks but the last in frequency overlap for the second
-                #     half in frequency
-                mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
-            if ct > 0:
-                # All chunks but the first in time overlap for the first half
-                #     in time
-                mask[:, : cwt // 2] *= mask_func(cwt // 2)
-            if ct < nct - 1:
-                # All chunks but the last in time overlap for the second half
-                #     in time
-                mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+            mask = chunk_mask(chunk_new.shape, cf, ct, ncf, nct, cwf, cwt)
             if idx > 0:
                 phi = p[idx - 1]
             else:
@@ -2133,26 +2085,7 @@ def fullMosGrad(p, chunks, dspec, N):
                 cf * cwf // 2: cf * cwf // 2 + cwf,
                 ct * cwt // 2: ct * cwt // 2 + cwt,
             ]
-            mask = np.ones(y.shape)
-
-            # Determine Mask for new chunk (chunks will have higher weights
-            #     towards their centre)
-            if cf > 0:
-                # All chunks but the first in frequency overlap for the first
-                #     half in frequency
-                mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-            if cf < ncf - 1:
-                # All chunks but the last in frequency overlap for the second
-                #     half in frequency
-                mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
-            if ct > 0:
-                # All chunks but the first in time overlap for the first half
-                #     in time
-                mask[:, : cwt // 2] *= mask_func(cwt // 2)
-            if ct < nct - 1:
-                # All chunks but the last in time overlap for the second half
-                #     in time
-                mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+            mask = chunk_mask(y.shape, cf, ct, ncf, nct, cwf, cwt)
             y *= mask
             if idx > 0:
                 phi = p[idx - 1]
@@ -2221,26 +2154,7 @@ def fullMosHess(p, chunks, dspec, N):
                 cfN * cwf // 2: cfN * cwf // 2 + cwf,
                 ctN * cwt // 2: ctN * cwt // 2 + cwt,
             ]
-            mask = np.ones(yN.shape)
-
-            # Determine Mask for new chunk (chunks will have higher weights
-            #     towards their centre)
-            if cfN > 0:
-                # All chunks but the first in frequency overlap for the first
-                #     half in frequency
-                mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
-            if cfN < ncf - 1:
-                # All chunks but the last in frequency overlap for the second
-                #     half in frequency
-                mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
-            if ctN > 0:
-                # All chunks but the first in time overlap for the first half
-                #     in time
-                mask[:, : cwt // 2] *= mask_func(cwt // 2)
-            if ctN < nct - 1:
-                # All chunks but the last in time overlap for the second half
-                #     in time
-                mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+            mask = chunk_mask(yN.shape, cfN, ctN, ncf, nct, cwf, cwt)
             yN *= mask
             idpN = idxN - 1
             if idpN > -1:
@@ -2291,30 +2205,8 @@ def fullMosHess(p, chunks, dspec, N):
                     if -1 < cfM < ncf and -1 < ctM < nct:
                         idxM = cfM * nct + ctM
                         yM = np.copy(chunks[cfM, ctM, :, :])
-                        mask = np.ones(yN.shape)
-
-                        # Determine Mask for new chunk (chunks will have higher
-                        #     weights towards their centre)
-                        if cfM > 0:
-                            # All chunks but the first in frequency overlap for
-                            #     the first half in frequency
-                            mask[: cwf // 2, :] *= mask_func(cwf // 2)[
-                                :, np.newaxis
-                            ]
-                        if cfM < ncf - 1:
-                            # All chunks but the last in frequency overlap for
-                            #     the second half in frequency
-                            mask[cwf // 2:, :] *= (
-                                1 - mask_func(cwf // 2)[:, np.newaxis]
-                            )
-                        if ctM > 0:
-                            # All chunks but the first in time overlap for the
-                            #     first half in time
-                            mask[:, : cwt // 2] *= mask_func(cwt // 2)
-                        if ctM < nct - 1:
-                            # All chunks but the last in time overlap for the
-                            #     second half in time
-                            mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+                        mask = chunk_mask(yN.shape, cfM, ctM, ncf, nct,
+                                          cwf, cwt)
                         yM *= mask
                         idpM = idxM - 1
                         if idpM > -1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+"""
+Shared pytest configuration for the scintools test suite.
+"""
+
+import matplotlib
+matplotlib.use('Agg')  # noqa: E402 - must happen before any pyplot import

--- a/tests/test_dynspec.py
+++ b/tests/test_dynspec.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for the lightweight wrapper classes in scintools.dynspec.
+
+These cover regressions for bugs found in the code review: BasicDyn's
+mutable-default / ``.size``-on-list handling and SimDyn reading
+``self.header`` before it was set.
+"""
+
+import numpy as np
+import pytest
+
+from scintools.dynspec import BasicDyn, SimDyn
+from scintools.scint_sim import Simulation
+
+
+# ---------------------------------------------------------------------------
+# BasicDyn
+# ---------------------------------------------------------------------------
+
+def test_basicdyn_accepts_list_axes():
+    # Regression: previously raised AttributeError because the guard called
+    # ``.size`` on a list default.
+    dyn = np.ones((4, 3))
+    bd = BasicDyn(dyn, times=[0, 1, 2], freqs=[1400, 1401, 1402, 1403])
+    assert bd.nsub == 3
+    assert bd.nchan == 4
+    np.testing.assert_allclose(bd.tobs, 3.0)
+    np.testing.assert_allclose(bd.dt, 1.0)
+
+
+def test_basicdyn_missing_axes_raises_valueerror():
+    # Regression: should raise the intended ValueError, not AttributeError.
+    with pytest.raises(ValueError):
+        BasicDyn(np.ones((1, 1)))
+
+
+def test_basicdyn_default_header_not_shared():
+    # Regression: mutable default header must not be shared between instances.
+    a = BasicDyn(np.ones((2, 2)), times=[0, 1], freqs=[1, 2])
+    b = BasicDyn(np.ones((2, 2)), times=[0, 1], freqs=[1, 2])
+    a.header.append("mutated")
+    assert b.header == ["BasicDyn"]
+
+
+# ---------------------------------------------------------------------------
+# SimDyn
+# ---------------------------------------------------------------------------
+
+def test_simdyn_from_simulation():
+    # Regression: SimDyn.__init__ used to do ``self.header = self.header``,
+    # raising AttributeError before header was defined.
+    sim = Simulation(ns=32, nf=8, verbose=False)
+    sd = SimDyn(sim)
+    assert isinstance(sd.header, list)
+    assert sd.dyn.ndim == 2
+    assert sd.nsub > 0 and sd.nchan > 0

--- a/tests/test_scint_models.py
+++ b/tests/test_scint_models.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for scintools.scint_models
+
+Focuses on pure model/residual functions that can be exercised with small
+synthetic data and lmfit Parameters objects, without invoking an actual
+fitter (Minimizer) or optional heavy dependencies (emcee, bilby).
+"""
+
+import numpy as np
+import pytest
+from lmfit import Parameters
+from numpy.testing import assert_allclose
+
+from scintools.scint_models import (
+    fit_parabola,
+    fit_log_parabola,
+    powerspectrum_model,
+    tau_acf_model,
+    dnu_acf_model,
+    scint_acf_model,
+    arc_power_curve,
+)
+
+
+# ---------------------------------------------------------------------------
+# fit_parabola / fit_log_parabola
+# ---------------------------------------------------------------------------
+
+def test_fit_parabola_recovers_known_peak():
+    x = np.linspace(-5, 5, 21)
+    true_peak = 1.5
+    y = -2 * (x - true_peak) ** 2 + 10
+
+    yfit, peak, peak_error = fit_parabola(x, y)
+
+    assert_allclose(peak, true_peak, atol=1e-6)
+    assert_allclose(yfit, y, atol=1e-6)
+    assert peak_error < 1e-6
+
+
+def test_fit_log_parabola_recovers_known_peak():
+    x = np.linspace(1, 10, 20)
+    true_log_peak = 1.0
+    y = -3 * (np.log(x) - true_log_peak) ** 2 + 5
+
+    yfit, peak, peak_error = fit_log_parabola(x, y)
+
+    assert_allclose(peak, np.e, rtol=1e-5)
+    assert peak_error < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# powerspectrum_model
+# ---------------------------------------------------------------------------
+
+def test_powerspectrum_model_zero_residual_at_truth():
+    params = Parameters()
+    params.add('amp', value=2.0)
+    params.add('wn', value=0.5)
+    params.add('alpha', value=-1.0)
+
+    xdata = np.array([1.0, 2.0, 4.0])
+    ydata = 0.5 + 2.0 * xdata ** (-1.0)
+
+    resid = powerspectrum_model(params, xdata, ydata)
+    assert_allclose(resid, np.zeros_like(xdata), atol=1e-12)
+
+
+def test_powerspectrum_model_nonzero_residual_when_off():
+    params = Parameters()
+    params.add('amp', value=2.0)
+    params.add('wn', value=0.5)
+    params.add('alpha', value=-1.0)
+
+    xdata = np.array([1.0, 2.0, 4.0])
+    ydata = np.array([100.0, 100.0, 100.0])
+
+    resid = powerspectrum_model(params, xdata, ydata)
+    assert np.all(np.abs(resid) > 0)
+
+
+# ---------------------------------------------------------------------------
+# tau_acf_model / dnu_acf_model / scint_acf_model
+# ---------------------------------------------------------------------------
+
+def _tau_params():
+    p = Parameters()
+    p.add('amp', value=1.0)
+    p.add('tau', value=5.0)
+    p.add('alpha', value=5 / 3)
+    return p
+
+
+def _dnu_params():
+    p = Parameters()
+    p.add('amp', value=1.0)
+    p.add('dnu', value=3.0)
+    return p
+
+
+def test_tau_acf_model_zero_residual_at_truth():
+    params = _tau_params()
+    xdata = np.linspace(0, 10, 11)
+    amp, tau, alpha = 1.0, 5.0, 5 / 3
+    model = amp * np.exp(-np.divide(xdata, tau) ** alpha)
+    model = model * (1 - xdata / max(xdata))
+    ydata = model.copy()
+    weights = np.ones_like(xdata)
+
+    resid = tau_acf_model(params, xdata, ydata, weights)
+    assert_allclose(resid, np.zeros_like(xdata), atol=1e-10)
+
+
+def test_dnu_acf_model_zero_residual_at_truth():
+    params = _dnu_params()
+    xdata = np.linspace(0, 6, 7)
+    amp, dnu = 1.0, 3.0
+    model = amp * np.exp(-np.divide(xdata, dnu / np.log(2)))
+    model = model * (1 - xdata / max(xdata))
+    ydata = model.copy()
+    weights = np.ones_like(xdata)
+
+    resid = dnu_acf_model(params, xdata, ydata, weights)
+    assert_allclose(resid, np.zeros_like(xdata), atol=1e-10)
+
+
+def test_scint_acf_model_concatenates_both_residuals():
+    params = _tau_params()
+    params.add('dnu', value=3.0)
+
+    xdata_t = np.linspace(0, 10, 11)
+    amp, tau, alpha = 1.0, 5.0, 5 / 3
+    model_t = amp * np.exp(-np.divide(xdata_t, tau) ** alpha)
+    model_t = model_t * (1 - xdata_t / max(xdata_t))
+    ydata_t = model_t.copy()
+
+    xdata_f = np.linspace(0, 6, 7)
+    dnu = 3.0
+    model_f = amp * np.exp(-np.divide(xdata_f, dnu / np.log(2)))
+    model_f = model_f * (1 - xdata_f / max(xdata_f))
+    ydata_f = model_f.copy()
+
+    weights_t = np.ones_like(xdata_t)
+    weights_f = np.ones_like(xdata_f)
+
+    resid = scint_acf_model(params, [xdata_t, xdata_f], [ydata_t, ydata_f],
+                             [weights_t, weights_f])
+
+    assert len(resid) == len(xdata_t) + len(xdata_f)
+    assert_allclose(resid, np.zeros_like(resid), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# arc_power_curve - flagged as broken (see report)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    reason=(
+        "arc_power_curve() in scintools/scint_models.py is an unfinished "
+        "stub: it sets `model = []` unconditionally and then computes "
+        "`(ydata - model) * weights`, which raises a numpy broadcasting "
+        "ValueError for any non-empty ydata instead of returning residuals."
+    ),
+    strict=True,
+)
+def test_arc_power_curve_returns_residuals_not_error():
+    xdata = np.array([1.0, 2.0, 3.0])
+    ydata = np.array([1.0, 2.0, 3.0])
+    resid = arc_power_curve(None, xdata, ydata, None)
+    assert len(resid) == len(ydata)

--- a/tests/test_scint_models.py
+++ b/tests/test_scint_models.py
@@ -18,7 +18,9 @@ from scintools.scint_models import (
     tau_acf_model,
     dnu_acf_model,
     scint_acf_model,
+    scint_sspec_model,
     arc_power_curve,
+    effective_velocity_annual,
 )
 
 
@@ -111,6 +113,17 @@ def test_tau_acf_model_zero_residual_at_truth():
     assert_allclose(resid, np.zeros_like(xdata), atol=1e-10)
 
 
+def test_tau_acf_model_does_not_mutate_caller_weights():
+    # Regression: the model used to zero weights[0] in place, mutating the
+    # caller's array.
+    params = _tau_params()
+    xdata = np.linspace(0, 10, 11)
+    ydata = np.ones_like(xdata)
+    weights = np.ones_like(xdata)
+    tau_acf_model(params, xdata, ydata, weights)
+    assert weights[0] == 1.0  # untouched
+
+
 def test_dnu_acf_model_zero_residual_at_truth():
     params = _dnu_params()
     xdata = np.linspace(0, 6, 7)
@@ -154,17 +167,51 @@ def test_scint_acf_model_concatenates_both_residuals():
 # arc_power_curve - flagged as broken (see report)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "arc_power_curve() in scintools/scint_models.py is an unfinished "
-        "stub: it sets `model = []` unconditionally and then computes "
-        "`(ydata - model) * weights`, which raises a numpy broadcasting "
-        "ValueError for any non-empty ydata instead of returning residuals."
-    ),
-    strict=True,
-)
-def test_arc_power_curve_returns_residuals_not_error():
+# arc_power_curve is an unimplemented template. It now raises an explicit
+# NotImplementedError instead of silently producing a broadcasting error.
+def test_arc_power_curve_raises_not_implemented():
     xdata = np.array([1.0, 2.0, 3.0])
     ydata = np.array([1.0, 2.0, 3.0])
-    resid = arc_power_curve(None, xdata, ydata, None)
-    assert len(resid) == len(ydata)
+    with pytest.raises(NotImplementedError):
+        arc_power_curve(None, xdata, ydata, None)
+
+
+# ---------------------------------------------------------------------------
+# scint_sspec_model - regression: the _sspec_model callees now accept an
+# optional weights argument, so this no longer raises TypeError.
+# ---------------------------------------------------------------------------
+
+def test_scint_sspec_model_runs_with_weights():
+    params = _tau_params()
+    params.add('dnu', value=3.0)
+    xdata_t = np.linspace(0, 10, 11)
+    xdata_f = np.linspace(0, 6, 7)
+    ydata_t = np.ones_like(xdata_t)
+    ydata_f = np.ones_like(xdata_f)
+    weights_t = np.ones_like(xdata_t)
+    weights_f = np.ones_like(xdata_f)
+
+    resid = scint_sspec_model(params,
+                              (xdata_t, xdata_f),
+                              (ydata_t, ydata_f),
+                              (weights_t, weights_f))
+    assert len(resid) == len(xdata_t) + len(xdata_f)
+    assert np.all(np.isfinite(resid))
+
+
+# ---------------------------------------------------------------------------
+# effective_velocity_annual - regression: a missing inclination parameter
+# now raises a clear KeyError instead of a later NameError on INC.
+# ---------------------------------------------------------------------------
+
+def test_effective_velocity_annual_missing_inclination_raises():
+    params = Parameters()
+    params.add('A1', value=1.0)
+    params.add('PB', value=10.0)
+    params.add('ECC', value=0.0)
+    params.add('OM', value=0.0)
+    params.add('KOM', value=0.0)
+    ta = np.array([0.0, 1.0])
+    ve = np.zeros_like(ta)
+    with pytest.raises(KeyError):
+        effective_velocity_annual(params, ta, ve, ve)

--- a/tests/test_scint_sim.py
+++ b/tests/test_scint_sim.py
@@ -6,7 +6,6 @@ calculations run in well under a second.
 """
 
 import numpy as np
-import pytest
 
 from scintools.scint_sim import Simulation, ACF
 
@@ -48,19 +47,10 @@ def test_simulation_intensity_is_non_negative():
 
 
 # ---------------------------------------------------------------------------
-# ACF - blocked by a real numpy>=2.0 incompatibility, see report
+# ACF - previously blocked by a numpy>=2.0 incompatibility (np.complex_),
+# now fixed (uses np.complex128).
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    reason=(
-        "scintools/scint_sim.py:589 and :634 (ACF.calc_acf) use "
-        "`dtype=np.complex_`, an alias removed in numpy>=2.0 "
-        "(NEP 51 / numpy 2.0 release notes); instantiating ACF() raises "
-        "AttributeError: `np.complex_` was removed in the NumPy 2.0 "
-        "release. Use `np.complex128` instead."
-    ),
-    strict=True,
-)
 def test_acf_small_grid_shape_and_peak():
     acf = ACF(nt=11, nf=11, taumax=2, dnumax=2, amp=1.0, wn=0.0,
               auto_sampling=True)

--- a/tests/test_scint_sim.py
+++ b/tests/test_scint_sim.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for scintools.scint_sim
+
+Uses small grid sizes so that the (otherwise expensive) simulation and ACF
+calculations run in well under a second.
+"""
+
+import numpy as np
+import pytest
+
+from scintools.scint_sim import Simulation, ACF
+
+
+# ---------------------------------------------------------------------------
+# Simulation
+# ---------------------------------------------------------------------------
+
+def test_simulation_produces_expected_dynspec_shape():
+    sim = Simulation(ns=32, nf=16, seed=42, verbose=False)
+
+    # self.dyn is transposed to (nchan, nsub)
+    assert sim.dyn.shape == (sim.nchan, sim.nsub)
+    assert sim.dyn.shape == (16, 32)
+
+
+def test_simulation_output_is_finite_and_real():
+    sim = Simulation(ns=32, nf=16, seed=1, verbose=False)
+    assert np.all(np.isfinite(sim.dyn))
+    assert np.isrealobj(sim.dyn)
+
+
+def test_simulation_frequency_and_time_axes_lengths():
+    sim = Simulation(ns=20, nf=12, seed=7, verbose=False)
+    assert len(sim.freqs) == sim.nchan
+    assert len(sim.times) == sim.nsub
+
+
+def test_simulation_is_deterministic_with_seed():
+    sim1 = Simulation(ns=16, nf=8, seed=123, verbose=False)
+    sim2 = Simulation(ns=16, nf=8, seed=123, verbose=False)
+    np.testing.assert_allclose(sim1.dyn, sim2.dyn)
+
+
+def test_simulation_intensity_is_non_negative():
+    # dynamic spectrum intensity (spi = |E|^2) should be non-negative
+    sim = Simulation(ns=16, nf=8, seed=5, verbose=False)
+    assert np.all(sim.dyn >= 0)
+
+
+# ---------------------------------------------------------------------------
+# ACF - blocked by a real numpy>=2.0 incompatibility, see report
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    reason=(
+        "scintools/scint_sim.py:589 and :634 (ACF.calc_acf) use "
+        "`dtype=np.complex_`, an alias removed in numpy>=2.0 "
+        "(NEP 51 / numpy 2.0 release notes); instantiating ACF() raises "
+        "AttributeError: `np.complex_` was removed in the NumPy 2.0 "
+        "release. Use `np.complex128` instead."
+    ),
+    strict=True,
+)
+def test_acf_small_grid_shape_and_peak():
+    acf = ACF(nt=11, nf=11, taumax=2, dnumax=2, amp=1.0, wn=0.0,
+              auto_sampling=True)
+
+    assert acf.acf.shape == (acf.nf, acf.nt)
+    # peak of the ACF should be at the centre and equal to amp
+    centre = (acf.acf.shape[0] // 2, acf.acf.shape[1] // 2)
+    np.testing.assert_allclose(acf.acf[centre], acf.amp, atol=1e-6)
+    assert np.isclose(np.max(acf.acf), acf.amp, atol=1e-6)

--- a/tests/test_scint_utils.py
+++ b/tests/test_scint_utils.py
@@ -1,0 +1,349 @@
+"""
+Unit tests for scintools.scint_utils
+
+These tests focus on pure/deterministic helper functions that do not
+require external data files, GUIs, or optional heavy dependencies.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from scintools.scint_utils import (
+    autocorr,
+    is_valid,
+    cov_to_corr,
+    float_array_from_dict,
+    difference,
+    mjd_to_year,
+    find_nearest,
+    longest_run_of_zeros,
+    centres_to_edges,
+    interp_nan_2d,
+    svd_model,
+    get_window,
+    scint_velocity,
+    read_par,
+    write_results,
+    read_results,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_valid
+# ---------------------------------------------------------------------------
+
+def test_is_valid_masks_nan_and_inf():
+    arr = np.array([1.0, np.nan, np.inf, -np.inf, 2.0])
+    result = is_valid(arr)
+    assert_allclose(result, [True, False, False, False, True])
+
+
+def test_is_valid_all_finite():
+    arr = np.array([1.0, 2.0, -3.5])
+    assert np.all(is_valid(arr))
+
+
+# ---------------------------------------------------------------------------
+# autocorr
+# ---------------------------------------------------------------------------
+
+def test_autocorr_shape_and_normalisation():
+    rng = np.random.default_rng(0)
+    small = np.ma.array(rng.random((3, 3)))
+    ac = autocorr(small)
+    # output is (2*nr, 2*nc)
+    assert ac.shape == (6, 6)
+    # normalised by its own max
+    assert_allclose(np.nanmax(ac), 1.0)
+
+
+def test_autocorr_symmetric_for_constant_array():
+    # a constant array has zero variance in the numerator terms away from
+    # zero lag, but the autocorrelation should still be point-symmetric:
+    # autocorr[x, y] == autocorr[-x, -y]
+    rng = np.random.default_rng(1)
+    arr = np.ma.array(rng.random((4, 4)))
+    ac = autocorr(arr)
+    flipped = ac[::-1, ::-1]
+    # the peak (lag 0,0) maps to itself under this flip only for even-sized
+    # arrays shifted by one; check general point symmetry away from edges
+    assert_allclose(ac, np.roll(np.roll(flipped, 1, axis=0), 1, axis=1),
+                     atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# cov_to_corr
+# ---------------------------------------------------------------------------
+
+def test_cov_to_corr_diagonal_is_one():
+    cov = np.array([[4.0, 2.0], [2.0, 9.0]])
+    corr = cov_to_corr(cov)
+    assert_allclose(np.diag(corr), [1.0, 1.0])
+    # known off-diagonal value: 2 / sqrt(4*9) = 1/3
+    assert_allclose(corr[0, 1], 1.0 / 3.0)
+    assert_allclose(corr[1, 0], 1.0 / 3.0)
+
+
+def test_cov_to_corr_zero_variance_entry_is_zero():
+    cov = np.array([[0.0, 0.0], [0.0, 9.0]])
+    corr = cov_to_corr(cov)
+    assert corr[0, 0] == 0
+    assert corr[0, 1] == 0
+    assert corr[1, 0] == 0
+
+
+# ---------------------------------------------------------------------------
+# float_array_from_dict
+# ---------------------------------------------------------------------------
+
+def test_float_array_from_dict_converts_strings():
+    d = {'x': ['1', '2.5', '3']}
+    result = float_array_from_dict(d, 'x')
+    assert_allclose(result, [1.0, 2.5, 3.0])
+
+
+def test_float_array_from_dict_handles_none_as_nan():
+    d = {'x': ['1', 'None', '3']}
+    result = float_array_from_dict(d, 'x')
+    assert result[0] == 1.0
+    assert np.isnan(result[1])
+    assert result[2] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# difference
+# ---------------------------------------------------------------------------
+
+def test_difference_matches_central_difference():
+    x = np.array([0.0, 1.0, 3.0, 6.0])
+    result = difference(x)
+    # first: (1-0)/2 = 0.5
+    # second: (3-0)/2 = 1.5
+    # third: (6-1)/2 = 2.5
+    # last: (6-3)/2 = 1.5
+    assert_allclose(result, [0.5, 1.5, 2.5, 1.5])
+
+
+def test_difference_same_length_as_input():
+    x = np.linspace(0, 10, 15)
+    result = difference(x)
+    assert len(result) == len(x)
+
+
+# ---------------------------------------------------------------------------
+# mjd_to_year
+# ---------------------------------------------------------------------------
+
+def test_mjd_to_year_known_epoch():
+    # MJD 51544.0 corresponds to 2000-01-01 00:00 UTC
+    yr = mjd_to_year(51544.0)
+    assert_allclose(yr, 2000.0, atol=0.01)
+
+
+def test_mjd_to_year_another_epoch():
+    # MJD 58849.0 corresponds to 2020-01-01 00:00 UTC
+    yr = mjd_to_year(58849.0)
+    assert_allclose(yr, 2020.0, atol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# find_nearest
+# ---------------------------------------------------------------------------
+
+def test_find_nearest_basic():
+    arr = [1, 5, 10]
+    assert find_nearest(arr, 6) == 1
+    assert find_nearest(arr, 0) == 0
+    assert find_nearest(arr, 11) == 2
+
+
+def test_find_nearest_exact_match():
+    arr = np.array([2.0, 4.0, 8.0])
+    assert find_nearest(arr, 4.0) == 1
+
+
+# ---------------------------------------------------------------------------
+# longest_run_of_zeros
+# ---------------------------------------------------------------------------
+
+def test_longest_run_of_zeros_basic():
+    arr = [1, 0, 0, 0, 1, 0, 0, 1]
+    assert longest_run_of_zeros(arr) == 3
+
+
+def test_longest_run_of_zeros_no_zeros():
+    arr = [1, 2, 3]
+    assert longest_run_of_zeros(arr) == 0
+
+
+def test_longest_run_of_zeros_all_zeros():
+    arr = [0, 0, 0, 0]
+    assert longest_run_of_zeros(arr) == 4
+
+
+# ---------------------------------------------------------------------------
+# centres_to_edges
+# ---------------------------------------------------------------------------
+
+def test_centres_to_edges_length():
+    arr = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    edges = centres_to_edges(arr)
+    assert len(edges) == len(arr) + 1
+
+
+def test_centres_to_edges_values():
+    arr = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    edges = centres_to_edges(arr)
+    assert_allclose(edges, [-0.5, 0.5, 1.5, 2.5, 3.5, 4.5])
+
+
+# ---------------------------------------------------------------------------
+# interp_nan_2d
+# ---------------------------------------------------------------------------
+
+def test_interp_nan_2d_fills_interior_nan():
+    ii, jj = np.meshgrid(np.arange(5), np.arange(5))
+    data = (ii + jj).astype(float)
+    data_with_nan = data.copy()
+    data_with_nan[2, 2] = np.nan
+
+    filled = interp_nan_2d(data_with_nan)
+
+    assert not np.isnan(filled[2, 2])
+    # since the underlying function is linear (i+j), interpolation at an
+    # interior point should recover the original value almost exactly
+    assert_allclose(filled[2, 2], data[2, 2], atol=1e-8)
+    # points that were not nan should stay (nearly) the same
+    mask = ~np.isnan(data_with_nan)
+    assert_allclose(filled[mask], data[mask], atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# svd_model
+# ---------------------------------------------------------------------------
+
+def test_svd_model_reconstructs_rank1_matrix():
+    u = np.array([1.0, 2.0, 3.0])
+    v = np.array([4.0, 5.0, 6.0, 7.0])
+    mat = np.outer(u, v).astype(complex)
+
+    arr_out, model = svd_model(mat, nmodes=1)
+
+    # a rank-1 matrix should be reconstructed (almost) exactly by 1 SVD mode
+    assert_allclose(np.abs(model), np.abs(mat), atol=1e-8)
+    # arr_out = mat / |model| should therefore be close to the phase of mat
+    assert arr_out.shape == mat.shape
+
+
+# ---------------------------------------------------------------------------
+# get_window
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('window', ['hanning', 'hamming', 'blackman',
+                                     'bartlett'])
+def test_get_window_returns_expected_lengths(window):
+    nt, nf = 20, 16
+    chan_window, subint_window = get_window(nt, nf, window=window, frac=0.1)
+    assert len(chan_window) == nt
+    assert len(subint_window) == nf
+
+
+# ---------------------------------------------------------------------------
+# scint_velocity
+# ---------------------------------------------------------------------------
+
+def test_scint_velocity_no_params():
+    # freq in MHz is divided by 1e3 to get GHz; with freq=1000 -> 1 GHz
+    a = 2.53e4
+    viss = scint_velocity(None, dnu=1.0, tau=1.0, freq=1000.0, a=a)
+    assert_allclose(viss, a)
+
+
+def test_scint_velocity_with_errors():
+    a = 2.53e4
+    dnu, tau, freq = 1.0, 1.0, 1000.0
+    dnuerr, tauerr = 0.1, 0.1
+    viss, viss_err = scint_velocity(None, dnu=dnu, tau=tau, freq=freq,
+                                     dnuerr=dnuerr, tauerr=tauerr, a=a)
+    assert_allclose(viss, a)
+    # manual calculation of expected error (coeff_err = 0 when params=None)
+    freq_ghz = freq / 1e3
+    expected_err = (1.0 / (freq_ghz * tau)) * np.sqrt(
+        a ** 2 * ((dnuerr ** 2 / (4 * dnu)) + (dnu * tauerr ** 2 / tau ** 2))
+    )
+    assert_allclose(viss_err, expected_err)
+
+
+# ---------------------------------------------------------------------------
+# read_par
+# ---------------------------------------------------------------------------
+
+def test_read_par_basic_parsing(tmp_path):
+    parfile = tmp_path / "test.par"
+    parfile.write_text(
+        "PSRJ J0000+0000\n"
+        "F0 100.0 1 1e-10\n"
+        "DM 20.0\n"
+        "# a comment line\n"
+        "JUMP -be PDFB 0.0\n"  # should be ignored
+    )
+
+    par = read_par(str(parfile))
+
+    assert par['PSRJ'] == 'J0000+0000'
+    assert par['PSRJ_TYPE'] == 's'
+
+    assert_allclose(par['F0'], 100.0)
+    assert_allclose(par['F0_ERR'], 1e-10)
+    assert par['F0_TYPE'] == 'f'
+
+    assert_allclose(par['DM'], 20.0)
+    assert 'JUMP' not in par
+
+
+def test_read_par_ignores_dmmodel_lines(tmp_path):
+    parfile = tmp_path / "test2.par"
+    parfile.write_text(
+        "PX 0.5\n"
+        "DMMODEL something 1.0\n"
+    )
+    par = read_par(str(parfile))
+    assert_allclose(par['PX'], 0.5)
+    assert 'DMMODEL' not in par
+
+
+# ---------------------------------------------------------------------------
+# write_results / read_results (round trip)
+# ---------------------------------------------------------------------------
+
+class _FakeDyn:
+    """Minimal stand-in for a Dynspec object with only the attributes
+    write_results() looks for."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def test_write_and_read_results_roundtrip(tmp_path):
+    outfile = tmp_path / "results.txt"
+
+    dyn1 = _FakeDyn(name='obs1', mjd=59000.0, freq=1400.0, bw=100.0,
+                    tobs=1800.0, dt=10.0, df=1.0, tau=100.0, tauerr=5.0)
+    dyn2 = _FakeDyn(name='obs2', mjd=59001.0, freq=1400.0, bw=100.0,
+                    tobs=1800.0, dt=10.0, df=1.0, tau=110.0, tauerr=6.0)
+
+    write_results(str(outfile), dyn1)
+    write_results(str(outfile), dyn2)
+
+    results = read_results(str(outfile))
+
+    assert results['name'] == ['obs1', 'obs2']
+    assert results['tau'] == ['100.0', '110.0']
+    assert results['tauerr'] == ['5.0', '6.0']
+
+    # header should only be written once
+    lines = outfile.read_text().splitlines()
+    assert lines[0] == "name,mjd,freq,bw,tobs,dt,df,tau,tauerr"
+    assert len(lines) == 3

--- a/tests/test_scint_utils.py
+++ b/tests/test_scint_utils.py
@@ -21,11 +21,13 @@ from scintools.scint_utils import (
     centres_to_edges,
     interp_nan_2d,
     svd_model,
+    svd_reconstruct,
     get_window,
     scint_velocity,
     read_par,
     write_results,
     read_results,
+    slow_FT,
 )
 
 
@@ -347,3 +349,43 @@ def test_write_and_read_results_roundtrip(tmp_path):
     lines = outfile.read_text().splitlines()
     assert lines[0] == "name,mjd,freq,bw,tobs,dt,df,tau,tauerr"
     assert len(lines) == 3
+
+
+# ---------------------------------------------------------------------------
+# svd_reconstruct / svd_model (shared SVD core)
+# ---------------------------------------------------------------------------
+
+def test_svd_reconstruct_matches_svd_model_core():
+    rng = np.random.default_rng(7)
+    arr = rng.standard_normal((6, 5)) + 1j * rng.standard_normal((6, 5))
+    _, model = svd_model(arr.copy(), nmodes=2)
+    assert np.array_equal(model, svd_reconstruct(arr.copy(), nmodes=2))
+
+
+def test_svd_model_normalises_by_abs_model():
+    rng = np.random.default_rng(8)
+    arr = rng.standard_normal((5, 4)) + 1j * rng.standard_normal((5, 4))
+    normed, model = svd_model(arr.copy(), nmodes=1)
+    assert_allclose(normed, arr / np.abs(model))
+
+
+# ---------------------------------------------------------------------------
+# slow_FT - regression: previously raised TypeError (fftshift axis kwarg)
+# ---------------------------------------------------------------------------
+
+def test_slow_ft_runs_and_has_expected_shape():
+    rng = np.random.default_rng(9)
+    dynspec = rng.standard_normal((8, 6))
+    freqs = np.linspace(1400.0, 1410.0, 6)
+    ss = slow_FT(dynspec, freqs)
+    assert ss.shape == dynspec.shape
+    assert ss.dtype == np.complex128
+
+
+def test_slow_ft_default_fref_is_midband():
+    rng = np.random.default_rng(10)
+    dynspec = rng.standard_normal((8, 6))
+    freqs = np.linspace(1400.0, 1410.0, 6)
+    ss_default = slow_FT(dynspec, freqs)
+    ss_explicit = slow_FT(dynspec, freqs, fref=freqs[len(freqs) // 2])
+    assert np.array_equal(ss_default, ss_explicit)

--- a/tests/test_ththmod.py
+++ b/tests/test_ththmod.py
@@ -1,0 +1,177 @@
+"""
+Unit tests for scintools.ththmod
+
+Covers small, deterministic helper functions that do not require an actual
+conjugate/secondary spectrum data set.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+import astropy.units as u
+from numpy.testing import assert_allclose
+
+from scintools.ththmod import (
+    svd_model,
+    chi_par,
+    len_arc,
+    ext_find,
+    fft_axis,
+    unit_checks,
+    arc_edges,
+    min_edges,
+)
+
+
+# ---------------------------------------------------------------------------
+# svd_model
+# ---------------------------------------------------------------------------
+
+def test_svd_model_reconstructs_rank1_matrix():
+    u_vec = np.array([1.0, 2.0, 3.0])
+    v_vec = np.array([4.0, 5.0, 6.0, 7.0])
+    mat = np.outer(u_vec, v_vec).astype(complex)
+
+    model = svd_model(mat, nmodes=1)
+
+    assert model.shape == mat.shape
+    assert_allclose(model, mat, atol=1e-8)
+
+
+def test_svd_model_zero_modes_gives_zero_matrix():
+    mat = np.eye(3, dtype=complex)
+    model = svd_model(mat, nmodes=0)
+    assert_allclose(model, np.zeros_like(mat), atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# chi_par
+# ---------------------------------------------------------------------------
+
+def test_chi_par_matches_parabola_formula():
+    x = 3.0
+    A, x0, C = 2.0, 1.0, 5.0
+    result = chi_par(x, A, x0, C)
+    assert_allclose(result, A * (x - x0) ** 2 + C)
+
+
+def test_chi_par_apex_value():
+    A, x0, C = 4.0, 2.0, -1.0
+    # at the apex x == x0, the parabola should equal C exactly
+    assert_allclose(chi_par(x0, A, x0, C), C)
+
+
+# ---------------------------------------------------------------------------
+# len_arc
+# ---------------------------------------------------------------------------
+
+def test_len_arc_zero_at_origin():
+    assert_allclose(len_arc(0.0, 2.0), 0.0)
+
+
+def test_len_arc_approx_linear_for_small_curvature():
+    # for very small curvature the arc length of a near-flat parabola
+    # should approximately equal the x-offset
+    result = len_arc(1.0, 1e-4)
+    assert_allclose(result, 1.0, atol=1e-3)
+
+
+def test_len_arc_is_odd_function():
+    eta = 0.5
+    assert_allclose(len_arc(2.0, eta), -len_arc(-2.0, eta))
+
+
+# ---------------------------------------------------------------------------
+# ext_find
+# ---------------------------------------------------------------------------
+
+def test_ext_find_basic():
+    x = np.array([1.0, 2.0, 3.0, 4.0]) * u.mHz
+    y = np.array([10.0, 20.0, 30.0]) * u.us
+
+    ext = ext_find(x, y)
+
+    assert_allclose(ext, [0.5, 4.5, 5.0, 35.0])
+
+
+# ---------------------------------------------------------------------------
+# fft_axis
+# ---------------------------------------------------------------------------
+
+def test_fft_axis_length_matches_input():
+    x = np.arange(10) * u.s
+    fx = fft_axis(x, u.Hz, pad=0)
+    assert len(fx) == len(x)
+    assert fx.unit == u.Hz
+
+
+def test_fft_axis_padding_increases_length():
+    x = np.arange(8) * u.s
+    fx_nopad = fft_axis(x, u.Hz, pad=0)
+    fx_pad = fft_axis(x, u.Hz, pad=1)
+    assert len(fx_pad) == 2 * len(fx_nopad)
+
+
+# ---------------------------------------------------------------------------
+# unit_checks
+# ---------------------------------------------------------------------------
+
+def test_unit_checks_assigns_units_when_missing():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        out = unit_checks(5.0, 'test', u.mHz)
+    assert out.unit == u.mHz
+    assert_allclose(out.value, 5.0)
+    assert len(caught) == 1
+    assert 'missing units' in str(caught[0].message)
+
+
+def test_unit_checks_passes_through_correct_units():
+    out = unit_checks(5.0 * u.mHz, 'test', u.mHz)
+    assert out.unit == u.mHz
+    assert_allclose(out.value, 5.0)
+
+
+def test_unit_checks_converts_equivalent_units():
+    out = unit_checks(5.0 * u.Hz, 'test', u.mHz)
+    assert out.unit == u.mHz
+    assert_allclose(out.value, 5000.0)
+
+
+def test_unit_checks_raises_for_incompatible_units():
+    with pytest.raises(u.UnitConversionError):
+        unit_checks(5.0 * u.s, 'test', u.mHz)
+
+
+# ---------------------------------------------------------------------------
+# arc_edges / min_edges
+# ---------------------------------------------------------------------------
+
+def test_arc_edges_returns_symmetric_even_length_array():
+    eta = 1.0 * u.us / u.mHz ** 2
+    dfd = 1.0 * u.mHz
+    dtau = 1.0 * u.us
+    fd_max = 10.0 * u.mHz
+
+    edges = arc_edges(eta, dfd, dtau, fd_max, 10)
+
+    assert len(edges) == 10
+    # symmetric about zero
+    assert_allclose(edges, -edges[::-1])
+    # strictly increasing
+    assert np.all(np.diff(edges) > 0)
+
+
+def test_min_edges_spans_requested_range():
+    eta = 1.0 * u.us / u.mHz ** 2
+    fd = np.linspace(-10, 10, 21) * u.mHz
+    tau = np.linspace(-5, 5, 11) * u.us
+    fd_lim = 5 * u.mHz
+
+    edges = min_edges(fd_lim, fd, tau, eta, factor=2)
+
+    assert_allclose(edges[0].value, -5.0)
+    assert_allclose(edges[-1].value, 5.0)
+    # even number of edges as documented
+    assert len(edges) % 2 == 0

--- a/tests/test_ththmod.py
+++ b/tests/test_ththmod.py
@@ -21,7 +21,10 @@ from scintools.ththmod import (
     unit_checks,
     arc_edges,
     min_edges,
+    chunk_mask,
+    mask_func,
 )
+from scintools.scint_utils import svd_reconstruct
 
 
 # ---------------------------------------------------------------------------
@@ -37,6 +40,47 @@ def test_svd_model_reconstructs_rank1_matrix():
 
     assert model.shape == mat.shape
     assert_allclose(model, mat, atol=1e-8)
+
+
+def test_svd_model_delegates_to_shared_core():
+    # Regression: ththmod.svd_model and scint_utils.svd_reconstruct share
+    # one implementation and must agree exactly.
+    rng = np.random.default_rng(3)
+    mat = rng.standard_normal((6, 5)) + 1j * rng.standard_normal((6, 5))
+    assert np.array_equal(svd_model(mat, nmodes=2),
+                          svd_reconstruct(mat, nmodes=2))
+
+
+# ---------------------------------------------------------------------------
+# chunk_mask (shared mosaic weighting mask)
+# ---------------------------------------------------------------------------
+
+def test_chunk_mask_matches_inline_logic():
+    # Reference implementation matching the pre-refactor inline block.
+    def ref(shape, cf, ct, ncf, nct, cwf, cwt):
+        mask = np.ones(shape)
+        if cf > 0:
+            mask[: cwf // 2, :] *= mask_func(cwf // 2)[:, np.newaxis]
+        if cf < ncf - 1:
+            mask[cwf // 2:, :] *= 1 - mask_func(cwf // 2)[:, np.newaxis]
+        if ct > 0:
+            mask[:, : cwt // 2] *= mask_func(cwt // 2)
+        if ct < nct - 1:
+            mask[:, cwt // 2:] *= 1 - mask_func(cwt // 2)
+        return mask
+
+    ncf, nct, cwf, cwt = 3, 3, 4, 6
+    for cf in range(ncf):
+        for ct in range(nct):
+            got = chunk_mask((cwf, cwt), cf, ct, ncf, nct, cwf, cwt)
+            assert np.array_equal(got, ref((cwf, cwt), cf, ct, ncf, nct,
+                                           cwf, cwt))
+
+
+def test_chunk_mask_single_chunk_is_all_ones():
+    # A lone chunk (ncf=nct=1) has no neighbours to cross-fade with.
+    mask = chunk_mask((4, 4), 0, 0, 1, 1, 4, 4)
+    assert np.array_equal(mask, np.ones((4, 4)))
 
 
 def test_svd_model_zero_modes_gives_zero_matrix():


### PR DESCRIPTION
## Overview

This PR improves documentation, test coverage, and code quality across `scintools`, then fixes the bugs surfaced by the review and applies safe refactors. Work was done on the `dev` branch across four commits.

## Documentation
- **Docstrings**: every function/method/class now has a NumPy-style docstring (165/165), plus module-level docstrings for all five modules. Verified via AST comparison that the docstring commit changed *only* docstrings — executable code was byte-identical to `master`.
- **Online docs** (`docs/source/`): rewrote the placeholder `dynspec.rst` and `simulation.rst` pages with real, runnable examples drawn from the example notebooks; filled in `acf.rst`; and reconciled `scint_models.rst`/`scint_utils.rst`/`acf.rst` signatures with the actual code (e.g. `thin_screen` → `veff_thin_screen`, corrected the stale `ACF` signature, fixed wrong defaults/types, removed stale entries).

## Tests
- New `pytest` suite under `tests/` covering the pure/deterministic functions in `scint_utils`, `scint_models`, `ththmod`, `scint_sim`, and the `dynspec` wrapper classes. **74 passing.**

## Bug fixes
Fixes all 10 confirmed bugs from the review (see `CODE_REVIEW.md`), plus 4 plausible issues and a `plt.colorbar` no-op. Highlights:
- `np.complex_` (removed in NumPy 2.0) → `np.complex128`, which unblocks the entire `ACF` class and the analytic 2D ACF fit path.
- `fit_arc` no longer crashes with `TypeError` in its default mode (list-vs-float division on `constraint`).
- `SimDyn.__init__` no longer raises `AttributeError` (`self.header = self.header`).
- `get_scint_params` 2D-crop copy/paste slip (`tmin/tmax` → `fmin/fmax`).
- `BasicDyn` mutable defaults / `.size`-on-list; `MatlabDyn` `except NameError` → `KeyError`; `calc_sspec` wrong cache attribute; `plot_dyn` mask; `norm_sspec` logsteps mask; in-place weight mutation; `np.float128` → `np.longdouble`.
- **New bug found during the fix pass**: `slow_FT` called `np.fft.fftshift(SS, axis=0)` — numpy's kwarg is `axes`, so it raised `TypeError` on every call. Fixed, and made the mid-band reference frequency an optional `fref` parameter.

## Refactors
All behavior-preserving (verified by imports, the test suite, and bit-for-bit output comparison against captured baselines for the untested mosaic code):
- Consolidated the duplicated `svd_model` onto a shared `svd_reconstruct` core.
- Extracted the ~6×-repeated mosaic weighting block in `ththmod.py` into a single `chunk_mask` helper (output verified bit-identical across all 9 affected functions).
- `scale_dyn` now reuses `get_window`; centralized the `c = 299792458.0` literal onto `scipy.constants.c`; removed a large commented-out dead block.

## Deliberately left for maintainer review (documented in `CODE_REVIEW.md`)
- The `scint_velocity` error-propagation term (scientific formula needing domain confirmation).
- Decomposition of the long functions (`get_scint_params`, `fit_arc`, `norm_sspec`, `ACF.calc_acf`) — deferred until characterization tests exist, to avoid silently altering the untested scientific core.
- `calc_scattered_image` fill not merged into `interp_nan_2d` (different masking semantics); `trim_edges`' unused `remove_short_sub` documented as reserved rather than dropped (avoids an API break); `make_dynspec` placeholder left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG6cv3jHNLYv1TN2YWDqi3)_